### PR TITLE
Implement a game logger

### DIFF
--- a/pkg/logger/file_logger.go
+++ b/pkg/logger/file_logger.go
@@ -3,8 +3,8 @@ package logger
 import "os"
 
 type FileLogger struct {
-	logger Logger
-	file   *os.File
+	Logger
+	file *os.File
 }
 
 func NewFromFile(filename string) (FileLogger, error) {
@@ -16,23 +16,11 @@ func NewFromFile(filename string) (FileLogger, error) {
 func (fl *FileLogger) Open(filename string) error {
 	file, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	fl.file = file
-	fl.logger = Logger{file}
+	fl.writer = file
 	return err
 }
 
 func (fl *FileLogger) Close() error {
 	err := fl.file.Close()
 	return err
-}
-
-func (fl *FileLogger) Start(deck []int, players []string) error {
-	return fl.logger.Start(deck, players)
-}
-
-func (fl *FileLogger) PlaceTile(player int, rotation int, position []int, meeple int) error {
-	return fl.logger.PlaceTile(player, rotation, position, meeple)
-}
-
-func (fl *FileLogger) End(scores []int) error {
-	return fl.logger.End(scores)
 }

--- a/pkg/logger/file_logger.go
+++ b/pkg/logger/file_logger.go
@@ -1,0 +1,38 @@
+package logger
+
+import "os"
+
+type FileLogger struct {
+	logger Logger
+	file   *os.File
+}
+
+func NewFromFile(filename string) (FileLogger, error) {
+	fileLogger := FileLogger{}
+	err := fileLogger.Open(filename)
+	return fileLogger, err
+}
+
+func (fl *FileLogger) Open(filename string) error {
+	file, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	fl.file = file
+	fl.logger = Logger{file}
+	return err
+}
+
+func (fl *FileLogger) Close() error {
+	err := fl.file.Close()
+	return err
+}
+
+func (fl *FileLogger) Start(deck []int, players []string) error {
+	return fl.logger.Start(deck, players)
+}
+
+func (fl *FileLogger) PlaceTile(player int, rotation int, position []int, meeple int) error {
+	return fl.logger.PlaceTile(player, rotation, position, meeple)
+}
+
+func (fl *FileLogger) End(scores []int) error {
+	return fl.logger.End(scores)
+}

--- a/pkg/logger/file_logger_test.go
+++ b/pkg/logger/file_logger_test.go
@@ -11,13 +11,11 @@ import (
 func TestLog(t *testing.T) {
 	filename := "test_file.jsonl"
 
-	file, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	log, err := NewFromFile(filename)
 	if err != nil {
 		t.Fatal("FAILED")
 	}
 	defer os.Remove(filename)
-
-	log := New(file)
 
 	if err != nil {
 		t.Fatal("FAILED")
@@ -57,8 +55,9 @@ func TestLog(t *testing.T) {
 		Scores []int
 	}
 
-	file.Close()
-	file, err = os.Open(filename)
+	log.Close()
+
+	file, err := os.Open(filename)
 	if err != nil {
 		t.Fatal("FAILED")
 	}

--- a/pkg/logger/log_entries.go
+++ b/pkg/logger/log_entries.go
@@ -1,0 +1,32 @@
+package logger
+
+type StartEntry struct {
+	Event   string   `json:"event"`
+	Deck    []int    `json:"deck"`
+	Players []string `json:"players"`
+}
+
+func NewStartEntry(deck []int, players []string) StartEntry {
+	return StartEntry{"start", deck, players}
+}
+
+type PlaceTileEntry struct {
+	Event    string `json:"event"`
+	Player   int    `json:"player"`
+	Rotation int    `json:"rotation"`
+	Position []int  `json:"position"`
+	Meeple   int    `json:"meeple"`
+}
+
+func NewPlaceTileEntry(player int, rotation int, position []int, meeple int) PlaceTileEntry {
+	return PlaceTileEntry{"place", player, rotation, position, meeple}
+}
+
+type EndEntry struct {
+	Event  string `json:"event"`
+	Scores []int  `json:"scores"`
+}
+
+func NewEndEntry(scores []int) EndEntry {
+	return EndEntry{"end", scores}
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -2,15 +2,15 @@ package logger
 
 import (
 	"encoding/json"
-	"os"
+	"io"
 )
 
 type Logger struct {
-	file *os.File
+	writer io.Writer
 }
 
-func New(file os.File) Logger {
-	return Logger{&file}
+func New(writer io.Writer) Logger {
+	return Logger{writer}
 }
 
 func (logger *Logger) logEvent(event map[string]interface{}) error {
@@ -21,23 +21,12 @@ func (logger *Logger) logEvent(event map[string]interface{}) error {
 
 	jsonData = append(jsonData, byte('\n'))
 
-	_, err = logger.file.Write(jsonData)
+	_, err = logger.writer.Write(jsonData)
 	if err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func (logger *Logger) Open(filename string) error {
-	file, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	logger.file = file
-	return err
-}
-
-func (logger *Logger) Close() error {
-	err := logger.file.Close()
-	return err
 }
 
 func (logger *Logger) Start(deck []int, players []string) error { // todo deck type should be: []tiles.Tile

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -78,7 +78,7 @@ func (logger *Logger) Start(deck []int, players []string) error { // todo deck t
 	return nil
 }
 
-func (logger *Logger) PlaceTile(player string, rotation int, position []int, meeple int) error { // todo meeple type should be connection.Side
+func (logger *Logger) PlaceTile(player int, rotation int, position []int, meeple int) error { // todo meeple type should be connection.Side
 	if logger.state != started {
 		return fmt.Errorf("logger already ended or not yet started")
 	}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -9,6 +9,10 @@ type Logger struct {
 	writer io.Writer
 }
 
+func New(writer io.Writer) Logger {
+	return Logger{writer}
+}
+
 func (logger *Logger) logEvent(event map[string]interface{}) error {
 	jsonData, err := json.Marshal(event)
 	if err != nil {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -9,19 +9,17 @@ type Logger struct {
 	writer io.Writer
 }
 
-func New(writer io.Writer) Logger {
-	return Logger{writer}
-}
-
 func (logger *Logger) logEvent(event map[string]interface{}) error {
 	jsonData, err := json.Marshal(event)
 	if err != nil {
 		return err
 	}
 
-	jsonData = append(jsonData, byte('\n'))
-
 	_, err = logger.writer.Write(jsonData)
+	if err != nil {
+		return err
+	}
+	_, err = logger.writer.Write([]byte("\n"))
 	if err != nil {
 		return err
 	}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,119 @@
+package logger
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type loggerState byte
+
+const (
+	new loggerState = iota
+	started
+	ended
+)
+
+type Logger struct {
+	filename string
+	state    loggerState
+}
+
+func New(filename string) Logger {
+	return Logger{filename, new}
+}
+
+func (logger *Logger) logEvent(event map[string]interface{}) error {
+	jsonData, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.OpenFile(logger.filename, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(string(jsonData) + "\n")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (logger *Logger) createFile() error {
+	file, err := os.Create(logger.filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return nil
+}
+
+func (logger *Logger) Start(deck []int, players []string) error { // todo deck type should be: []tiles.Tile
+	if logger.state != new {
+		return fmt.Errorf("logger already started")
+	}
+
+	err := logger.createFile()
+	if err != nil {
+		return err
+	}
+
+	err = logger.logEvent(
+		map[string]interface{}{
+			"event":   "start",
+			"deck":    deck,
+			"players": players,
+		})
+	if err != nil {
+		return err
+	}
+
+	logger.state = started
+
+	return nil
+}
+
+func (logger *Logger) PlaceTile(player string, rotation int, position []int, meeple int) error { // todo meeple type should be connection.Side
+	if logger.state != started {
+		return fmt.Errorf("logger already ended or not yet started")
+	}
+
+	err := logger.logEvent(
+		map[string]interface{}{
+			"event":    "place",
+			"player":   player,
+			"rotation": rotation,
+			"position": position,
+			"meeple":   meeple,
+		})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (logger *Logger) End(scores []int) error {
+	if logger.state != started {
+		return fmt.Errorf("logger already ended or not yet started")
+	}
+
+	err := logger.logEvent(
+		map[string]interface{}{
+			"event":  "end",
+			"scores": scores,
+		})
+
+	if err != nil {
+		return err
+	}
+
+	logger.state = ended
+
+	return nil
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -13,7 +13,7 @@ func New(writer io.Writer) Logger {
 	return Logger{writer}
 }
 
-func (logger *Logger) logEvent(event map[string]interface{}) error {
+func (logger *Logger) LogEvent(event interface{}) error {
 	jsonData, err := json.Marshal(event)
 	if err != nil {
 		return err
@@ -29,35 +29,4 @@ func (logger *Logger) logEvent(event map[string]interface{}) error {
 	}
 
 	return nil
-}
-
-func (logger *Logger) Start(deck []int, players []string) error { // todo deck type should be: []tiles.Tile
-	err := logger.logEvent(
-		map[string]interface{}{
-			"event":   "start",
-			"deck":    deck,
-			"players": players,
-		})
-	return err
-}
-
-func (logger *Logger) PlaceTile(player int, rotation int, position []int, meeple int) error { // todo meeple type should be connection.Side
-	err := logger.logEvent(
-		map[string]interface{}{
-			"event":    "place",
-			"player":   player,
-			"rotation": rotation,
-			"position": position,
-			"meeple":   meeple,
-		})
-	return err
-}
-
-func (logger *Logger) End(scores []int) error {
-	err := logger.logEvent(
-		map[string]interface{}{
-			"event":  "end",
-			"scores": scores,
-		})
-	return err
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -6,11 +6,11 @@ import (
 )
 
 type Logger struct {
-	filename string
+	file *os.File
 }
 
-func New(filename string) Logger {
-	return Logger{filename}
+func New(file os.File) Logger {
+	return Logger{&file}
 }
 
 func (logger *Logger) logEvent(event map[string]interface{}) error {
@@ -19,13 +19,9 @@ func (logger *Logger) logEvent(event map[string]interface{}) error {
 		return err
 	}
 
-	file, err := os.OpenFile(logger.filename, os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
+	jsonData = append(jsonData, byte('\n'))
 
-	_, err = file.WriteString(string(jsonData) + "\n")
+	_, err = logger.file.Write(jsonData)
 	if err != nil {
 		return err
 	}
@@ -33,33 +29,25 @@ func (logger *Logger) logEvent(event map[string]interface{}) error {
 	return nil
 }
 
-func (logger *Logger) createFile() error {
-	file, err := os.Create(logger.filename)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
+func (logger *Logger) Open(filename string) error {
+	file, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	logger.file = file
+	return err
+}
 
-	return nil
+func (logger *Logger) Close() error {
+	err := logger.file.Close()
+	return err
 }
 
 func (logger *Logger) Start(deck []int, players []string) error { // todo deck type should be: []tiles.Tile
-	err := logger.createFile()
-	if err != nil {
-		return err
-	}
-
-	err = logger.logEvent(
+	err := logger.logEvent(
 		map[string]interface{}{
 			"event":   "start",
 			"deck":    deck,
 			"players": players,
 		})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (logger *Logger) PlaceTile(player int, rotation int, position []int, meeple int) error { // todo meeple type should be connection.Side
@@ -71,11 +59,7 @@ func (logger *Logger) PlaceTile(player int, rotation int, position []int, meeple
 			"position": position,
 			"meeple":   meeple,
 		})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (logger *Logger) End(scores []int) error {
@@ -84,10 +68,5 @@ func (logger *Logger) End(scores []int) error {
 			"event":  "end",
 			"scores": scores,
 		})
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -2,25 +2,15 @@ package logger
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
-)
-
-type loggerState byte
-
-const (
-	new loggerState = iota
-	started
-	ended
 )
 
 type Logger struct {
 	filename string
-	state    loggerState
 }
 
 func New(filename string) Logger {
-	return Logger{filename, new}
+	return Logger{filename}
 }
 
 func (logger *Logger) logEvent(event map[string]interface{}) error {
@@ -54,10 +44,6 @@ func (logger *Logger) createFile() error {
 }
 
 func (logger *Logger) Start(deck []int, players []string) error { // todo deck type should be: []tiles.Tile
-	if logger.state != new {
-		return fmt.Errorf("logger already started")
-	}
-
 	err := logger.createFile()
 	if err != nil {
 		return err
@@ -73,16 +59,10 @@ func (logger *Logger) Start(deck []int, players []string) error { // todo deck t
 		return err
 	}
 
-	logger.state = started
-
 	return nil
 }
 
 func (logger *Logger) PlaceTile(player int, rotation int, position []int, meeple int) error { // todo meeple type should be connection.Side
-	if logger.state != started {
-		return fmt.Errorf("logger already ended or not yet started")
-	}
-
 	err := logger.logEvent(
 		map[string]interface{}{
 			"event":    "place",
@@ -99,10 +79,6 @@ func (logger *Logger) PlaceTile(player int, rotation int, position []int, meeple
 }
 
 func (logger *Logger) End(scores []int) error {
-	if logger.state != started {
-		return fmt.Errorf("logger already ended or not yet started")
-	}
-
 	err := logger.logEvent(
 		map[string]interface{}{
 			"event":  "end",
@@ -112,8 +88,6 @@ func (logger *Logger) End(scores []int) error {
 	if err != nil {
 		return err
 	}
-
-	logger.state = ended
 
 	return nil
 }

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -10,15 +10,18 @@ import (
 
 func TestLog(t *testing.T) {
 	filename := "test_file.jsonl"
-	log := Logger{}
 
-	err := log.Open(filename)
+	file, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		t.Fatal("FAILED")
 	}
-
 	defer os.Remove(filename)
-	defer log.Close()
+
+	log := New(file)
+
+	if err != nil {
+		t.Fatal("FAILED")
+	}
 
 	err = log.Start([]int{1, 2, 3}, []string{"Player1", "Player2"})
 	if err != nil {
@@ -54,7 +57,8 @@ func TestLog(t *testing.T) {
 		Scores []int
 	}
 
-	file, err := os.Open(filename)
+	file.Close()
+	file, err = os.Open(filename)
 	if err != nil {
 		t.Fatal("FAILED")
 	}

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -22,39 +22,24 @@ func TestFileLogger(t *testing.T) {
 		t.Fatal("FAILED")
 	}
 
-	err = log.Start([]int{1, 2, 3}, []string{"Player1", "Player2"})
+	err = log.LogEvent(NewStartEntry([]int{1, 2, 3}, []string{"Player1", "Player2"}))
 	if err != nil {
 		t.Fatal("FAILED")
 	}
 
-	err = log.PlaceTile(0, 1, []int{1, 2}, 0)
+	err = log.LogEvent(NewPlaceTileEntry(0, 1, []int{1, 2}, 0))
 	if err != nil {
 		t.Fatal("FAILED")
 	}
 
-	err = log.End([]int{1, 2})
+	err = log.LogEvent(NewEndEntry([]int{1, 2}))
 	if err != nil {
 		t.Fatal("FAILED")
 	}
 
-	var startLine struct {
-		Event   string
-		Deck    []int
-		Players []string
-	}
-
-	var placeTileLine struct {
-		Event    string
-		Player   int
-		Rotation int
-		Position []int
-		Meeple   int
-	}
-
-	var endLine struct {
-		Event  string
-		Scores []int
-	}
+	var startLine StartEntry
+	var placeTileLine PlaceTileEntry
+	var endLine EndEntry
 
 	log.Close()
 
@@ -116,44 +101,29 @@ func TestLogger(t *testing.T) {
 
 	log := New(buffer)
 
-	err := log.Start([]int{1, 2, 3}, []string{"Player1", "Player2"})
+	err := log.LogEvent(NewStartEntry([]int{1, 2, 3}, []string{"Player1", "Player2"}))
 	if err != nil {
 		t.Fatal("FAILED")
 	}
 
-	err = log.PlaceTile(0, 1, []int{1, 2}, 0)
+	err = log.LogEvent(NewPlaceTileEntry(0, 1, []int{1, 2}, 0))
 	if err != nil {
 		t.Fatal("FAILED")
 	}
 
-	err = log.End([]int{1, 2})
+	err = log.LogEvent(NewEndEntry([]int{1, 2}))
 	if err != nil {
 		t.Fatal("FAILED")
-	}
-
-	var startLine struct {
-		Event   string
-		Deck    []int
-		Players []string
-	}
-
-	var placeTileLine struct {
-		Event    string
-		Player   int
-		Rotation int
-		Position []int
-		Meeple   int
-	}
-
-	var endLine struct {
-		Event  string
-		Scores []int
 	}
 
 	line, err := buffer.ReadString(byte('\n'))
 	if err != nil {
 		t.Fatal("FAILED")
 	}
+
+	var startLine StartEntry
+	var placeTileLine PlaceTileEntry
+	var endLine EndEntry
 
 	err = json.Unmarshal([]byte(line), &startLine)
 	if err != nil {

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -14,27 +14,27 @@ func TestFileLogger(t *testing.T) {
 
 	log, err := NewFromFile(filename)
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 	defer os.Remove(filename)
 
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 
 	err = log.LogEvent(NewStartEntry([]int{1, 2, 3}, []string{"Player1", "Player2"}))
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 
 	err = log.LogEvent(NewPlaceTileEntry(0, 1, []int{1, 2}, 0))
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 
 	err = log.LogEvent(NewEndEntry([]int{1, 2}))
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 
 	var startLine StartEntry
@@ -45,7 +45,7 @@ func TestFileLogger(t *testing.T) {
 
 	file, err := os.Open(filename)
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 	defer file.Close()
 
@@ -54,7 +54,7 @@ func TestFileLogger(t *testing.T) {
 	scanner.Scan()
 	err = json.Unmarshal([]byte(scanner.Text()), &startLine)
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 	if startLine.Event != "start" {
 		t.Fatal("FAILED")
@@ -69,7 +69,7 @@ func TestFileLogger(t *testing.T) {
 	scanner.Scan()
 	err = json.Unmarshal([]byte(scanner.Text()), &placeTileLine)
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 	if placeTileLine.Event != "place" {
 		t.Fatal("FAILED")
@@ -87,7 +87,7 @@ func TestFileLogger(t *testing.T) {
 	scanner.Scan()
 	err = json.Unmarshal([]byte(scanner.Text()), &endLine)
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 	if endLine.Event != "end" {
 		t.Fatal("FAILED")
@@ -102,13 +102,13 @@ func TestFileLoggerInvalidFiles(t *testing.T) {
 
 	log, err := NewFromFile(filename)
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 	defer os.Remove(filename)
 
 	err = log.Close()
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 
 	err = log.Close()
@@ -129,22 +129,22 @@ func TestLogger(t *testing.T) {
 
 	err := log.LogEvent(NewStartEntry([]int{1, 2, 3}, []string{"Player1", "Player2"}))
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 
 	err = log.LogEvent(NewPlaceTileEntry(0, 1, []int{1, 2}, 0))
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 
 	err = log.LogEvent(NewEndEntry([]int{1, 2}))
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 
 	line, err := buffer.ReadString(byte('\n'))
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 
 	var startLine StartEntry
@@ -153,7 +153,7 @@ func TestLogger(t *testing.T) {
 
 	err = json.Unmarshal([]byte(line), &startLine)
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 	if startLine.Event != "start" {
 		t.Fatal("FAILED")
@@ -167,11 +167,11 @@ func TestLogger(t *testing.T) {
 
 	line, err = buffer.ReadString(byte('\n'))
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 	err = json.Unmarshal([]byte(line), &placeTileLine)
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 	if placeTileLine.Event != "place" {
 		t.Fatal("FAILED")
@@ -188,11 +188,11 @@ func TestLogger(t *testing.T) {
 
 	line, err = buffer.ReadString(byte('\n'))
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 	err = json.Unmarshal([]byte(line), &endLine)
 	if err != nil {
-		t.Fatal("FAILED")
+		t.Fatal(err.Error())
 	}
 	if endLine.Event != "end" {
 		t.Fatal("FAILED")

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,140 @@
+package logger
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestLogWrongStates(t *testing.T) {
+	log := New("test_file.jsonl")
+
+	err := log.PlaceTile(1, 1, []int{1, 2}, 0)
+	if err == nil {
+		t.Fatal("FAILED")
+	}
+
+	err = log.End([]int{1, 2})
+	if err == nil {
+		t.Fatal("FAILED")
+	}
+
+	log.state = started
+
+	err = log.Start([]int{1, 2, 3}, []string{"Player1", "Player2"})
+	if err == nil {
+		t.Fatal("FAILED")
+	}
+
+	log.state = ended
+
+	err = log.Start([]int{1, 2, 3}, []string{"Player1", "Player2"})
+	if err == nil {
+		t.Fatal("FAILED")
+	}
+
+	err = log.PlaceTile(1, 1, []int{1, 2}, 0)
+	if err == nil {
+		t.Fatal("FAILED")
+	}
+
+	err = log.End([]int{1, 2})
+	if err == nil {
+		t.Fatal("FAILED")
+	}
+}
+
+func TestLog(t *testing.T) {
+	filename := "test_file.jsonl"
+	log := New(filename)
+	defer os.Remove(filename)
+
+	err := log.Start([]int{1, 2, 3}, []string{"Player1", "Player2"})
+	if err != nil {
+		t.Fatal("FAILED")
+	}
+
+	err = log.PlaceTile(0, 1, []int{1, 2}, 0)
+	if err != nil {
+		t.Fatal("FAILED")
+	}
+
+	err = log.End([]int{1, 2})
+	if err != nil {
+		t.Fatal("FAILED")
+	}
+
+	var startLine struct {
+		Event   string
+		Deck    []int
+		Players []string
+	}
+
+	var placeTileLine struct {
+		Event    string
+		Player   int
+		Rotation int
+		Position []int
+		Meeple   int
+	}
+
+	var endLine struct {
+		Event  string
+		Scores []int
+	}
+
+	file, err := os.Open(filename)
+	if err != nil {
+		t.Fatal("FAILED")
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+
+	scanner.Scan()
+	err = json.Unmarshal([]byte(scanner.Text()), &startLine)
+	if err != nil {
+		t.Fatal("FAILED")
+	}
+	if startLine.Event != "start" {
+		t.Fatal("FAILED")
+	}
+	if !reflect.DeepEqual(startLine.Deck, []int{1, 2, 3}) {
+		t.Fatal("FAILED")
+	}
+	if !reflect.DeepEqual(startLine.Players, []string{"Player1", "Player2"}) {
+		t.Fatal("FAILED")
+	}
+
+	scanner.Scan()
+	err = json.Unmarshal([]byte(scanner.Text()), &placeTileLine)
+	if err != nil {
+		t.Fatal("FAILED")
+	}
+	if placeTileLine.Event != "place" {
+		t.Fatal("FAILED")
+	}
+	if placeTileLine.Rotation != 1 {
+		t.Fatal("FAILED")
+	}
+	if !reflect.DeepEqual(placeTileLine.Position, []int{1, 2}) {
+		t.Fatal("FAILED")
+	}
+	if placeTileLine.Meeple != 0 {
+		t.Fatal("FAILED")
+	}
+
+	scanner.Scan()
+	err = json.Unmarshal([]byte(scanner.Text()), &endLine)
+	if err != nil {
+		t.Fatal("FAILED")
+	}
+	if endLine.Event != "end" {
+		t.Fatal("FAILED")
+	}
+	if !reflect.DeepEqual(endLine.Scores, []int{1, 2}) {
+		t.Fatal("FAILED")
+	}
+}

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -8,44 +8,6 @@ import (
 	"testing"
 )
 
-func TestLogWrongStates(t *testing.T) {
-	log := New("test_file.jsonl")
-
-	err := log.PlaceTile(1, 1, []int{1, 2}, 0)
-	if err == nil {
-		t.Fatal("FAILED")
-	}
-
-	err = log.End([]int{1, 2})
-	if err == nil {
-		t.Fatal("FAILED")
-	}
-
-	log.state = started
-
-	err = log.Start([]int{1, 2, 3}, []string{"Player1", "Player2"})
-	if err == nil {
-		t.Fatal("FAILED")
-	}
-
-	log.state = ended
-
-	err = log.Start([]int{1, 2, 3}, []string{"Player1", "Player2"})
-	if err == nil {
-		t.Fatal("FAILED")
-	}
-
-	err = log.PlaceTile(1, 1, []int{1, 2}, 0)
-	if err == nil {
-		t.Fatal("FAILED")
-	}
-
-	err = log.End([]int{1, 2})
-	if err == nil {
-		t.Fatal("FAILED")
-	}
-}
-
 func TestLog(t *testing.T) {
 	filename := "test_file.jsonl"
 	log := New(filename)

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -96,6 +96,32 @@ func TestFileLogger(t *testing.T) {
 		t.Fatal("FAILED")
 	}
 }
+
+func TestFileLoggerInvalidFiles(t *testing.T) {
+	filename := "test_file.jsonl"
+
+	log, err := NewFromFile(filename)
+	if err != nil {
+		t.Fatal("FAILED")
+	}
+	defer os.Remove(filename)
+
+	err = log.Close()
+	if err != nil {
+		t.Fatal("FAILED")
+	}
+
+	err = log.Close()
+	if err == nil {
+		t.Fatal("FAILED")
+	}
+
+	err = log.LogEvent(NewStartEntry([]int{1, 2, 3}, []string{"Player1", "Player2"}))
+	if err == nil {
+		t.Fatal("FAILED")
+	}
+}
+
 func TestLogger(t *testing.T) {
 	buffer := bytes.NewBuffer(nil)
 
@@ -174,5 +200,4 @@ func TestLogger(t *testing.T) {
 	if !reflect.DeepEqual(endLine.Scores, []int{1, 2}) {
 		t.Fatal("FAILED")
 	}
-
 }

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-//nolint:gosec// Cyclomatic complexity is not a problem in case of these tests
+//nolint:gocyclo// Cyclomatic complexity is not a problem in case of these tests
 func TestFileLogger(t *testing.T) {
 	filename := "test_file.jsonl"
 
@@ -123,7 +123,7 @@ func TestFileLoggerInvalidFiles(t *testing.T) {
 	}
 }
 
-//nolint:gosec// Cyclomatic complexity is not a problem in case of these tests
+//nolint:gocyclo// Cyclomatic complexity is not a problem in case of these tests
 func TestLogger(t *testing.T) {
 	buffer := bytes.NewBuffer(nil)
 

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 )
 
+//nolint:gosec// Cyclomatic complexity is not a problem in case of these tests
 func TestFileLogger(t *testing.T) {
 	filename := "test_file.jsonl"
 
@@ -122,6 +123,7 @@ func TestFileLoggerInvalidFiles(t *testing.T) {
 	}
 }
 
+//nolint:gosec// Cyclomatic complexity is not a problem in case of these tests
 func TestLogger(t *testing.T) {
 	buffer := bytes.NewBuffer(nil)
 

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -2,13 +2,14 @@ package logger
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"os"
 	"reflect"
 	"testing"
 )
 
-func TestLog(t *testing.T) {
+func TestFileLogger(t *testing.T) {
 	filename := "test_file.jsonl"
 
 	log, err := NewFromFile(filename)
@@ -109,4 +110,99 @@ func TestLog(t *testing.T) {
 	if !reflect.DeepEqual(endLine.Scores, []int{1, 2}) {
 		t.Fatal("FAILED")
 	}
+}
+func TestLogger(t *testing.T) {
+	buffer := bytes.NewBuffer(nil)
+
+	log := New(buffer)
+
+	err := log.Start([]int{1, 2, 3}, []string{"Player1", "Player2"})
+	if err != nil {
+		t.Fatal("FAILED")
+	}
+
+	err = log.PlaceTile(0, 1, []int{1, 2}, 0)
+	if err != nil {
+		t.Fatal("FAILED")
+	}
+
+	err = log.End([]int{1, 2})
+	if err != nil {
+		t.Fatal("FAILED")
+	}
+
+	var startLine struct {
+		Event   string
+		Deck    []int
+		Players []string
+	}
+
+	var placeTileLine struct {
+		Event    string
+		Player   int
+		Rotation int
+		Position []int
+		Meeple   int
+	}
+
+	var endLine struct {
+		Event  string
+		Scores []int
+	}
+
+	line, err := buffer.ReadString(byte('\n'))
+	if err != nil {
+		t.Fatal("FAILED")
+	}
+
+	err = json.Unmarshal([]byte(line), &startLine)
+	if err != nil {
+		t.Fatal("FAILED")
+	}
+	if startLine.Event != "start" {
+		t.Fatal("FAILED")
+	}
+	if !reflect.DeepEqual(startLine.Deck, []int{1, 2, 3}) {
+		t.Fatal("FAILED")
+	}
+	if !reflect.DeepEqual(startLine.Players, []string{"Player1", "Player2"}) {
+		t.Fatal("FAILED")
+	}
+
+	line, err = buffer.ReadString(byte('\n'))
+	if err != nil {
+		t.Fatal("FAILED")
+	}
+	err = json.Unmarshal([]byte(line), &placeTileLine)
+	if err != nil {
+		t.Fatal("FAILED")
+	}
+	if placeTileLine.Event != "place" {
+		t.Fatal("FAILED")
+	}
+	if placeTileLine.Rotation != 1 {
+		t.Fatal("FAILED")
+	}
+	if !reflect.DeepEqual(placeTileLine.Position, []int{1, 2}) {
+		t.Fatal("FAILED")
+	}
+	if placeTileLine.Meeple != 0 {
+		t.Fatal("FAILED")
+	}
+
+	line, err = buffer.ReadString(byte('\n'))
+	if err != nil {
+		t.Fatal("FAILED")
+	}
+	err = json.Unmarshal([]byte(line), &endLine)
+	if err != nil {
+		t.Fatal("FAILED")
+	}
+	if endLine.Event != "end" {
+		t.Fatal("FAILED")
+	}
+	if !reflect.DeepEqual(endLine.Scores, []int{1, 2}) {
+		t.Fatal("FAILED")
+	}
+
 }

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -10,10 +10,17 @@ import (
 
 func TestLog(t *testing.T) {
 	filename := "test_file.jsonl"
-	log := New(filename)
-	defer os.Remove(filename)
+	log := Logger{}
 
-	err := log.Start([]int{1, 2, 3}, []string{"Player1", "Player2"})
+	err := log.Open(filename)
+	if err != nil {
+		t.Fatal("FAILED")
+	}
+
+	defer os.Remove(filename)
+	defer log.Close()
+
+	err = log.Start([]int{1, 2, 3}, []string{"Player1", "Player2"})
 	if err != nil {
 		t.Fatal("FAILED")
 	}


### PR DESCRIPTION
Closes #7 

Example log:
```jsonl
{"event": "start", "deck": [1, 2, 3, 4], "players": ["ai", "human"]}
{"event": "place", "player": 0, "rotation": 2, "position": [1, 2], "meeple": 0}
{"event": "place", "player": 1, "rotation": 0, "position": [2, 3], "meeple": 1}
{"event": "end", "scores: [20, 10]"}
```

-----

Notes:
- Actions for drawing and discarding tiles are not logged, as they are automatic and don't involve any kind of player's choice.
- The "end" log is not strictly necessary, but it could be useful to determine the result of a game without having to replay it.
- The "meeple" and "deck" fields should be replaced with appropriate values once their PRs are merged.

-----

Resolved:
~The code coverage is at 70%, but I think most of the uncovered lines are related to error checking, for example when opening files. (i.e. `file, err := os.Create(logger.filename); if err != nil {return err}`) I'm not sure if it makes sense to test such cases. Should I remove the error checks and assume everything will work correctly?~