### PR TITLE
Fix for linter action

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Lint Code Base
         uses: super-linter/super-linter@v6.3.0
         env:
-          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: origin/main
           VALIDATE_GO: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pkg/stack/tile_stack.go
+++ b/pkg/stack/tile_stack.go
@@ -2,18 +2,18 @@ package stack
 
 import (
 	"errors"
-	"math/rand"
+	"math/rand" //nolint:gosec// Weak number generator is sufficent in our case
 	"time"
 )
 
 type Stack[T interface{}] struct {
-	seed    int64
-	turn_no int32
-	tiles   []T
-	order   []int32
+	seed   int64
+	turnNo int32
+	tiles  []T
+	order  []int32
 }
 
-var StackOutOfBoundsError = errors.New("stack: out of bounds")
+var ErrStackOutOfBounds = errors.New("stack: out of bounds")
 
 // New creates new Stack and shuffles it using current time as seed.
 // NODE: Input slice is not copied.
@@ -26,7 +26,7 @@ func New[T interface{}](tiles []T) Stack[T] {
 func NewSeeded[T interface{}](tiles []T, seed int64) Stack[T] {
 	stack := NewOrdered(tiles)
 	stack.seed = seed
-	rng := rand.New(rand.NewSource(stack.seed))
+	rng := rand.New(rand.NewSource(stack.seed)) //nolint:gosec// Weak number generator is sufficent in our case
 	rng.Shuffle(len(stack.order), func(i, j int) {
 		stack.order[i], stack.order[j] = stack.order[j], stack.order[i]
 	})
@@ -37,10 +37,10 @@ func NewSeeded[T interface{}](tiles []T, seed int64) Stack[T] {
 // NODE: Input slice is not copied.
 func NewOrdered[T interface{}](tiles []T) Stack[T] {
 	stack := Stack[T]{
-		seed:    0,
-		turn_no: 0,
-		tiles:   tiles,
-		order:   make([]int32, len(tiles)),
+		seed:   0,
+		turnNo: 0,
+		tiles:  tiles,
+		order:  make([]int32, len(tiles)),
 	}
 	for i := range len(tiles) {
 		stack.order[i] = int32(i)
@@ -50,7 +50,7 @@ func NewOrdered[T interface{}](tiles []T) Stack[T] {
 
 func (s Stack[T]) GetRemaining() []T {
 	tiles := []T{}
-	for _, i := range s.order[s.turn_no:] {
+	for _, i := range s.order[s.turnNo:] {
 		tiles = append(tiles, s.tiles[i])
 	}
 	return tiles
@@ -58,16 +58,16 @@ func (s Stack[T]) GetRemaining() []T {
 
 func (s Stack[T]) Get(n int32) (T, error) {
 	if n >= int32(len(s.tiles)) {
-		return *new(T), StackOutOfBoundsError
+		return *new(T), ErrStackOutOfBounds
 	}
 	return s.tiles[s.order[n]], nil
 }
 
 func (s *Stack[T]) Next() (T, error) {
-	defer func() { s.turn_no += 1 }()
-	return s.Get(s.turn_no)
+	defer func() { s.turnNo++ }()
+	return s.Get(s.turnNo)
 }
 
 func (s Stack[T]) Peek() (T, error) {
-	return s.Get(s.turn_no)
+	return s.Get(s.turnNo)
 }

--- a/pkg/stack/tile_stack_test.go
+++ b/pkg/stack/tile_stack_test.go
@@ -44,15 +44,15 @@ func TestPeek(t *testing.T) {
 	tiles := []Tile{{0}, {1}, {2}, {3}}
 	stack := NewOrdered(tiles)
 	for range len(tiles) {
-		tile_a, err := stack.Peek()
+		tileA, err := stack.Peek()
 		if err != nil {
 			t.Fatal(err.Error())
 		}
-		tile_b, err := stack.Next()
+		tileB, err := stack.Next()
 		if err != nil {
 			t.Fatal(err.Error())
 		}
-		if tile_a != tile_b {
+		if tileA != tileB {
 			t.Fail()
 		}
 	}
@@ -61,16 +61,19 @@ func TestPeek(t *testing.T) {
 func TestOutOfBounds(t *testing.T) {
 	tiles := []Tile{{0}}
 	stack := NewOrdered(tiles)
-	stack.Next()
-	_, err := stack.Peek()
+	_, err := stack.Next()
+	if err != nil {
+		t.Fail()
+	}
+	_, err = stack.Peek()
 	if err == nil {
 		t.Fail()
 	}
-	if err == nil || !errors.Is(err, StackOutOfBoundsError) {
+	if err == nil || !errors.Is(err, ErrStackOutOfBounds) {
 		t.Fail()
 	}
 	_, err = stack.Next()
-	if err == nil || !errors.Is(err, StackOutOfBoundsError) {
+	if err == nil || !errors.Is(err, ErrStackOutOfBounds) {
 		t.Fail()
 	}
 }
@@ -79,7 +82,10 @@ func TestRemaining(t *testing.T) {
 	tiles := []Tile{{0}, {1}, {2}, {3}}
 	stack := NewOrdered(tiles)
 	for range 2 {
-		stack.Next()
+		_, err := stack.Next()
+		if err != nil {
+			t.Fail()
+		}
 	}
 	remaining := stack.GetRemaining()
 	if remaining[0] != tiles[2] {


### PR DESCRIPTION
Prior to these changes golangci-lint would have ran only if go.mod file was modified.
This pull request supersedes #13 and resolves issues form the discussion.