### PR TITLE
Fix Side.Rotate() not working correctly for rotations > 1

### DIFF
--- a/pkg/tiles/side/side.go
+++ b/pkg/tiles/side/side.go
@@ -108,7 +108,7 @@ func (side Side) Rotate(rotations uint) Side { //nolint:gocyclo // splitting int
 	rotations %= 4
 	var result = side
 	for rotations > 0 {
-		switch side {
+		switch result {
 		case Top:
 			result = Right
 		case Right:

--- a/pkg/tiles/side/side_test.go
+++ b/pkg/tiles/side/side_test.go
@@ -83,6 +83,14 @@ func TestSideRotate(t *testing.T) { //nolint:gocyclo // simply testing all state
 	}
 }
 
+func TestSideRotateReturnsSideRotatedTwice(t *testing.T) {
+	expected := Bottom
+	actual := Top.Rotate(2)
+	if expected != actual {
+		t.Fatalf("expected %#v, got %#v instead", expected, actual)
+	}
+}
+
 func TestSideToString(t *testing.T) { //nolint:gocyclo // simply testing all states
 	if Top.String() != "TOP" {
 		t.Fatalf("got %#v should be %#v", Top.String(), "TOP")


### PR DESCRIPTION
Missed during the review of #9 - `Side.Rotate()` doesn't work correctly when `rotations` is above 1 as it keeps trying to rotate the input rather than the partial result.