### PR TITLE
Renamed package buildings->building; fixed typo

### DIFF
--- a/pkg/tiles/building/building.go
+++ b/pkg/tiles/building/building.go
@@ -1,13 +1,13 @@
-package buildings
+package building
 
-type Bulding int64
+type Building int64
 
 const (
-	None Bulding = iota
+	None Building = iota
 	Monastery
 )
 
-func (building Bulding) String() string {
+func (building Building) String() string {
 
 	switch building {
 	case None:

--- a/pkg/tiles/building/building_test.go
+++ b/pkg/tiles/building/building_test.go
@@ -1,4 +1,4 @@
-package buildings
+package building
 
 import (
 	"testing"
@@ -14,7 +14,7 @@ func TestBuildingToString(t *testing.T) {
 		t.Fatalf("got %#v should be %#v", Monastery.String(), "MONASTERY")
 	}
 
-	if Bulding(100).String() != "ERROR" {
-		t.Fatalf("got %#v should be %#v", Bulding(100).String(), "ERROR")
+	if Building(100).String() != "ERROR" {
+		t.Fatalf("got %#v should be %#v", Building(100).String(), "ERROR")
 	}
 }

--- a/pkg/tiles/tile.go
+++ b/pkg/tiles/tile.go
@@ -1,7 +1,7 @@
 package tiles
 
 import (
-	buildings "github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/buildings"
+	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/building"
 	featureMod "github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/feature"
 	sideMod "github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/side"
 )
@@ -12,7 +12,7 @@ Immutable object
 type Tile struct {
 	Features  []featureMod.Feature
 	HasShield bool
-	Building  buildings.Bulding
+	Building  building.Building
 }
 
 func (tile Tile) Equals(other Tile) bool {

--- a/pkg/tiles/tile_test.go
+++ b/pkg/tiles/tile_test.go
@@ -6,7 +6,7 @@ import (
 
 	//revive:disable-next-line:dot-imports Dot imports for package under test are fine.
 	. "github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles"
-	buildings "github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/buildings"
+	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/building"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/feature"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/side"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/tiletemplates"
@@ -74,7 +74,7 @@ func TestTileRotate(t *testing.T) {
 	tile.Features = append(tile.Features, feature.Feature{FeatureType: feature.Road, Sides: []side.Side{side.Bottom, side.Right}})
 	tile.Features = append(tile.Features, feature.Feature{FeatureType: feature.Field, Sides: []side.Side{side.BottomRightEdge, side.RightBottomEdge}})
 	tile.HasShield = true
-	tile.Building = buildings.None
+	tile.Building = building.None
 
 	var rotated = tile.Rotate(1)
 
@@ -83,7 +83,7 @@ func TestTileRotate(t *testing.T) {
 	expected.Features = append(expected.Features, feature.Feature{FeatureType: feature.Road, Sides: []side.Side{side.Left, side.Bottom}})
 	expected.Features = append(expected.Features, feature.Feature{FeatureType: feature.Field, Sides: []side.Side{side.LeftBottomEdge, side.BottomLeftEdge}})
 	expected.HasShield = true
-	expected.Building = buildings.None
+	expected.Building = building.None
 
 	if !reflect.DeepEqual(rotated, expected) {
 		t.Fatalf("got\n %#v \nshould be \n%#v", rotated, expected)
@@ -96,7 +96,7 @@ func TestTileFeatureGet(t *testing.T) {
 	tile.Features = append(tile.Features, feature.Feature{FeatureType: feature.Road, Sides: []side.Side{side.Bottom, side.Right}})
 	tile.Features = append(tile.Features, feature.Feature{FeatureType: feature.Field, Sides: []side.Side{side.BottomRightEdge, side.RightBottomEdge}})
 	tile.HasShield = true
-	tile.Building = buildings.None
+	tile.Building = building.None
 
 	var expectedCities = []feature.Feature{
 		{

--- a/pkg/tiles/tiletemplates/tile_templates.go
+++ b/pkg/tiles/tiletemplates/tile_templates.go
@@ -2,7 +2,7 @@ package tiletemplates
 
 import (
 	tiles "github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles"
-	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/buildings"
+	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/building"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/feature"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/side"
 )
@@ -28,7 +28,7 @@ func MonasteryWithoutRoads() tiles.Tile {
 			},
 		},
 		HasShield: false,
-		Building:  buildings.Monastery,
+		Building:  building.Monastery,
 	}
 }
 
@@ -63,7 +63,7 @@ func MonasteryWithSingleRoad() tiles.Tile {
 			},
 		},
 		HasShield: false,
-		Building:  buildings.Monastery,
+		Building:  building.Monastery,
 	}
 }
 
@@ -100,7 +100,7 @@ func StraightRoads() tiles.Tile {
 			},
 		},
 		HasShield: false,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -138,7 +138,7 @@ func RoadsTurn() tiles.Tile {
 			},
 		},
 		HasShield: false,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -196,7 +196,7 @@ func TCrossRoad() tiles.Tile {
 			},
 		},
 		HasShield: false,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -262,7 +262,7 @@ func XCrossRoad() tiles.Tile {
 			},
 		},
 		HasShield: false,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -291,7 +291,7 @@ func SingleCityEdgeNoRoads() tiles.Tile {
 			},
 		},
 		HasShield: false,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -333,7 +333,7 @@ func SingleCityEdgeStraightRoads() tiles.Tile {
 			},
 		},
 		HasShield: false,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -375,7 +375,7 @@ func SingleCityEdgeLeftRoadTurn() tiles.Tile {
 			},
 		},
 		HasShield: false,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -416,7 +416,7 @@ func SingleCityEdgeRightRoadTurn() tiles.Tile {
 			},
 		},
 		HasShield: false,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -476,7 +476,7 @@ func SingleCityEdgeCrossRoad() tiles.Tile {
 			},
 		},
 		HasShield: false,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -509,7 +509,7 @@ func TwoCityEdgesUpAndDownNotConnected() tiles.Tile {
 			},
 		},
 		HasShield: false,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -542,7 +542,7 @@ func TwoCityEdgesCornerNotConnected() tiles.Tile {
 			},
 		},
 		HasShield: false,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -576,7 +576,7 @@ func TwoCityEdgesUpAndDownConnected() tiles.Tile {
 			},
 		},
 		HasShield: false,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -610,7 +610,7 @@ func TwoCityEdgesUpAndDownConnectedShield() tiles.Tile {
 			},
 		},
 		HasShield: true,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -638,7 +638,7 @@ func TwoCityEdgesCornerConnected() tiles.Tile {
 			},
 		},
 		HasShield: false,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -667,7 +667,7 @@ func TwoCityEdgesCornerConnectedShield() tiles.Tile {
 			},
 		},
 		HasShield: true,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -707,7 +707,7 @@ func TwoCityEdgesCornerConnectedRoadTurn() tiles.Tile {
 			},
 		},
 		HasShield: false,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -747,7 +747,7 @@ func TwoCityEdgesCornerConnectedRoadTurnShield() tiles.Tile {
 			},
 		},
 		HasShield: true,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -775,7 +775,7 @@ func ThreeCityEdgesConnected() tiles.Tile {
 			},
 		},
 		HasShield: false,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -803,7 +803,7 @@ func ThreeCityEdgesConnectedShield() tiles.Tile {
 			},
 		},
 		HasShield: true,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -843,7 +843,7 @@ func ThreeCityEdgesConnectedRoad() tiles.Tile {
 			},
 		},
 		HasShield: false,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -883,7 +883,7 @@ func ThreeCityEdgesConnectedRoadShield() tiles.Tile {
 			},
 		},
 		HasShield: true,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }
 
@@ -905,6 +905,6 @@ func FourCityEdgesConnectedShield() tiles.Tile {
 			},
 		},
 		HasShield: true,
-		Building:  buildings.None,
+		Building:  building.None,
 	}
 }


### PR DESCRIPTION
The change is to match the convention with other tile-related things (`feature`, `side` - singular, not plural)

Also renamed `Bulding` type to `Building` lol