### PR TITLE
Replaced plain enum with bitmasks in Side

### DIFF
--- a/pkg/tiles/feature/feature.go
+++ b/pkg/tiles/feature/feature.go
@@ -1,8 +1,6 @@
 package feature
 
 import (
-	"slices"
-
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/side"
 )
 
@@ -17,12 +15,5 @@ const (
 
 type Feature struct {
 	FeatureType Type
-	Sides       []side.Side
-}
-
-func (feature Feature) Equals(other Feature) bool {
-	if feature.FeatureType != other.FeatureType {
-		return false
-	}
-	return slices.Equal(feature.Sides, other.Sides)
+	Sides       side.Side
 }

--- a/pkg/tiles/side/side.go
+++ b/pkg/tiles/side/side.go
@@ -83,7 +83,7 @@ func (side Side) String() string { //nolint:gocyclo // splitting into multiple s
 /*
 Rotates side clockwise
 */
-func (side Side) Rotate(rotations uint) Side { //nolint:gocyclo // splitting into multiple switches would be obscure
+func (side Side) Rotate(rotations uint) Side {
 	/*
 		Top             0b0000000000000001
 		Right           0b0000000000000010
@@ -115,7 +115,7 @@ func (side Side) Rotate(rotations uint) Side { //nolint:gocyclo // splitting int
 	result := side & ^Center
 
 	for rotations > 0 {
-		result = result << 1
+		result <<= 1
 
 		// loop the last 4 bits (rotated Left goes back into Top)
 		if result&0b1_0000 != 0 {

--- a/pkg/tiles/side/side.go
+++ b/pkg/tiles/side/side.go
@@ -40,7 +40,7 @@ const (
 	None Side = 0
 )
 
-func (side Side) String() string { //nolint:gocyclo // splitting into multiple switches would be obscure
+func (side Side) String() string {
 	sideNames := map[Side]string{
 		Top:             "TOP",
 		Right:           "RIGHT",

--- a/pkg/tiles/side/side.go
+++ b/pkg/tiles/side/side.go
@@ -1,43 +1,38 @@
 package side
 
-type Side int16
+type Side uint8
 
-// The order of sides in this enum matters for some bitwise operations in Rotate().
 const (
-	Top Side = 1 << iota
-	Right
-	Bottom
-	Left
-
-	// for fields
-
 	/* Left side of top edge */
-	TopLeftEdge
-
-	/* Top side of right edge */
-	RightTopEdge
-
-	/* Right side of bottom edge */
-	BottomRightEdge
-
-	/* Bottom side of left edge */
-	LeftBottomEdge
-
-	/* Top side of left edge */
-	LeftTopEdge
+	TopLeftEdge Side = 0b1000_0000
 
 	/* Right side of top edge */
-	TopRightEdge
+	TopRightEdge Side = 0b0100_0000
+
+	/* Top side of right edge */
+	RightTopEdge Side = 0b0010_0000
 
 	/* Bottom side of right edge */
-	RightBottomEdge
+	RightBottomEdge Side = 0b0001_0000
+
+	/* Right side of bottom edge */
+	BottomRightEdge Side = 0b0000_1000
 
 	/* Left side of bottom edge */
-	BottomLeftEdge
+	BottomLeftEdge Side = 0b0000_0100
 
-	Center
+	/* Bottom side of left edge */
+	LeftBottomEdge Side = 0b0000_0010
 
-	None Side = 0
+	/* Top side of left edge */
+	LeftTopEdge Side = 0b0000_0001
+
+	Top    Side = 0b1100_0000
+	Right  Side = 0b0011_0000
+	Bottom Side = 0b0000_1100
+	Left   Side = 0b0000_0011
+
+	None Side = 0b0000_0000
 )
 
 func (side Side) String() string {
@@ -54,7 +49,6 @@ func (side Side) String() string {
 		TopRightEdge:    "TOP_RIGHT_EDGE",
 		RightBottomEdge: "RIGHT_BOTTOM_EDGE",
 		BottomLeftEdge:  "BOTTOM_LEFT_EDGE",
-		Center:          "CENTER",
 	}
 	/*
 		First direction indicates the main edge of square, the second tells which side of the edge.
@@ -85,23 +79,24 @@ Rotates side clockwise
 */
 func (side Side) Rotate(rotations uint) Side {
 	/*
-		Top             0b0000000000000001
-		Right           0b0000000000000010
-		Bottom          0b0000000000000100
-		Left            0b0000000000001000
+		TopLeftEdge     0b10000000
+		TopRightEdge    0b01000000
 
-		TopLeftEdge     0b0000000000010000
-		RightTopEdge    0b0000000000100000
-		BottomRightEdge 0b0000000001000000
-		LeftBottomEdge  0b0000000010000000
+		RightTopEdge    0b00100000
+		RightBottomEdge 0b00010000
 
-		LeftTopEdge     0b0000000100000000
-		TopRightEdge    0b0000001000000000
-		RightBottomEdge 0b0000010000000000
-		BottomLeftEdge  0b0000100000000000
+		BottomRightEdge 0b00001000
+		BottomLeftEdge  0b00000100
 
-		Center          0b0001000000000000
-		None            0b0000000000000000
+		LeftBottomEdge  0b00000010
+		LeftTopEdge     0b00000001
+
+		Top             0b11000000
+		Right           0b00110000
+		Bottom          0b00001100
+		Left            0b00000011
+
+		None            0b00000000
 	*/
 
 	// limit rotations
@@ -110,35 +105,6 @@ func (side Side) Rotate(rotations uint) Side {
 		return side
 	}
 
-	// center doesn't rotate
-	hasCenter := side&Center != 0
-	result := side & ^Center
-
-	for rotations > 0 {
-		result <<= 1
-
-		// loop the last 4 bits (rotated Left goes back into Top)
-		if result&0b1_0000 != 0 {
-			result &= ^(1 << 4) // clear the overflowed bit
-			result |= (1 << 0)  // set the bit in correct position
-		}
-
-		// loop the next 4 bits (rotated LeftBottomEdge goes back into TopLeftEdge)
-		if result&0b1_0000_0000 != 0 {
-			result &= ^(1 << 8) // clear the overflowed bit
-			result |= (1 << 4)  // set the bit in correct position
-		}
-
-		// loop the next 4 bits (rotated BottomLeftEdge goes back into LeftTopEdge)
-		if result&0b1_0000_0000_0000 != 0 {
-			result &= ^(1 << 12) // clear the overflowed bit
-			result |= (1 << 8)   // set the bit in correct position
-		}
-		rotations--
-	}
-
-	if hasCenter {
-		result |= Center
-	}
-	return result
+	var shift = rotations * 2
+	return (side >> shift) | (side << (8 - shift)) // circular bitshift (bitwise rotate) side to the right by {2*rotations} bits
 }

--- a/pkg/tiles/side/side.go
+++ b/pkg/tiles/side/side.go
@@ -36,19 +36,45 @@ const (
 )
 
 func (side Side) String() string {
-	sideNames := map[Side]string{
-		Top:             "TOP",
-		Right:           "RIGHT",
-		Bottom:          "BOTTOM",
-		Left:            "LEFT",
-		TopLeftEdge:     "TOP_LEFT_EDGE",
-		RightTopEdge:    "RIGHT_TOP_EDGE",
-		BottomRightEdge: "BOTTOM_RIGHT_EDGE",
-		LeftBottomEdge:  "LEFT_BOTTOM_EDGE",
-		LeftTopEdge:     "LEFT_TOP_EDGE",
-		TopRightEdge:    "TOP_RIGHT_EDGE",
-		RightBottomEdge: "RIGHT_BOTTOM_EDGE",
-		BottomLeftEdge:  "BOTTOM_LEFT_EDGE",
+	type sideNamesStruct struct {
+		primary     Side
+		primaryName string
+		secondary   map[Side]string
+	}
+
+	sideNames := []sideNamesStruct{
+		{
+			primary:     Top,
+			primaryName: "TOP",
+			secondary: map[Side]string{
+				TopLeftEdge:  "TOP_LEFT_EDGE",
+				TopRightEdge: "TOP_RIGHT_EDGE",
+			},
+		},
+		{
+			primary:     Right,
+			primaryName: "RIGHT",
+			secondary: map[Side]string{
+				RightTopEdge:    "RIGHT_TOP_EDGE",
+				RightBottomEdge: "RIGHT_BOTTOM_EDGE",
+			},
+		},
+		{
+			primary:     Bottom,
+			primaryName: "BOTTOM",
+			secondary: map[Side]string{
+				BottomRightEdge: "BOTTOM_RIGHT_EDGE",
+				BottomLeftEdge:  "BOTTOM_LEFT_EDGE",
+			},
+		},
+		{
+			primary:     Left,
+			primaryName: "LEFT",
+			secondary: map[Side]string{
+				LeftBottomEdge: "LEFT_BOTTOM_EDGE",
+				LeftTopEdge:    "LEFT_TOP_EDGE",
+			},
+		},
 	}
 	/*
 		First direction indicates the main edge of square, the second tells which side of the edge.
@@ -61,9 +87,16 @@ func (side Side) String() string {
 			tile center
 	*/
 	output := ""
-	for key, value := range sideNames {
-		if side&key != 0 {
-			output += value
+
+	for _, names := range sideNames {
+		if side&names.primary == names.primary {
+			output += names.primaryName
+		} else {
+			for key, value := range names.secondary {
+				if side&key == key {
+					output += value
+				}
+			}
 		}
 	}
 
@@ -99,7 +132,6 @@ func (side Side) Rotate(rotations uint) Side {
 		None            0b00000000
 	*/
 
-	// limit rotations
 	rotations %= 4
 	if rotations == 0 {
 		return side

--- a/pkg/tiles/side/side.go
+++ b/pkg/tiles/side/side.go
@@ -1,164 +1,144 @@
 package side
 
-type Side int64
+type Side int16
 
+// The order of sides in this enum matters for some bitwise operations in Rotate().
 const (
-	None Side = iota
-	Top
+	Top Side = 1 << iota
 	Right
-	Left
 	Bottom
-
-	Center
-
-	// for farmers
-	TopLeftCorner
-	TopRightCorner
-	BottomLeftCorner
-	BottomRightCorner
+	Left
 
 	// for fields
 
 	/* Left side of top edge */
 	TopLeftEdge
-	/* Right side of top edge */
-	TopRightEdge
 
 	/* Top side of right edge */
 	RightTopEdge
-	/* Bottom side of right edge */
-	RightBottomEdge
 
-	/* Top side of left edge */
-	LeftTopEdge
+	/* Right side of bottom edge */
+	BottomRightEdge
+
 	/* Bottom side of left edge */
 	LeftBottomEdge
 
+	/* Top side of left edge */
+	LeftTopEdge
+
+	/* Right side of top edge */
+	TopRightEdge
+
+	/* Bottom side of right edge */
+	RightBottomEdge
+
 	/* Left side of bottom edge */
 	BottomLeftEdge
-	/* Right side of bottom edge */
-	BottomRightEdge
+
+	Center
+
+	None Side = 0
 )
 
 func (side Side) String() string { //nolint:gocyclo // splitting into multiple switches would be obscure
-
-	switch side {
-	case Top:
-		return "TOP"
-	case Right:
-		return "RIGHT"
-	case Left:
-		return "LEFT"
-	case Bottom:
-		return "BOTTOM"
-
-	case TopLeftCorner:
-		return "TOP_LEFT_CORNER"
-	case TopRightCorner:
-		return "TOP_RIGHT_CORNER"
-	case BottomLeftCorner:
-		return "BOTTOM_LEFT_CORNER"
-	case BottomRightCorner:
-		return "BOTTOM_RIGHT_CORNER"
-
-	case Center:
-		return "CENTER"
-
-		/*
-			First direction indicates the main edge of square, the second tells which side of the edge.
-			Example:"
-			TopLeftEdge
-			 <______
-					|
-					|
-					|
-				tile center
-		*/
-
-	case TopLeftEdge:
-		return "TOP_LEFT_EDGE"
-	case TopRightEdge:
-		return "TOP_RIGHT_EDGE"
-	case RightTopEdge:
-		return "RIGHT_TOP_EDGE"
-	case RightBottomEdge:
-		return "RIGHT_BOTTOM_EDGE"
-
-	case LeftTopEdge:
-		return "LEFT_TOP_EDGE"
-	case LeftBottomEdge:
-		return "LEFT_BOTTOM_EDGE"
-	case BottomLeftEdge:
-		return "BOTTOM_LEFT_EDGE"
-	case BottomRightEdge:
-		return "BOTTOM_RIGHT_EDGE"
-
-	case None:
-		return "NONE"
-	default:
-		return "ERROR"
+	sideNames := map[Side]string{
+		Top:             "TOP",
+		Right:           "RIGHT",
+		Bottom:          "BOTTOM",
+		Left:            "LEFT",
+		TopLeftEdge:     "TOP_LEFT_EDGE",
+		RightTopEdge:    "RIGHT_TOP_EDGE",
+		BottomRightEdge: "BOTTOM_RIGHT_EDGE",
+		LeftBottomEdge:  "LEFT_BOTTOM_EDGE",
+		LeftTopEdge:     "LEFT_TOP_EDGE",
+		TopRightEdge:    "TOP_RIGHT_EDGE",
+		RightBottomEdge: "RIGHT_BOTTOM_EDGE",
+		BottomLeftEdge:  "BOTTOM_LEFT_EDGE",
+		Center:          "CENTER",
 	}
+	/*
+		First direction indicates the main edge of square, the second tells which side of the edge.
+		Example:"
+		TopLeftEdge
+		 <______
+				|
+				|
+				|
+			tile center
+	*/
+	output := ""
+	for key, value := range sideNames {
+		if side&key != 0 {
+			output += value
+		}
+	}
+
+	if output == "" {
+		output = "NONE"
+	}
+
+	return output
 }
 
 /*
 Rotates side clockwise
 */
 func (side Side) Rotate(rotations uint) Side { //nolint:gocyclo // splitting into multiple switches would be obscure
+	/*
+		Top             0b0000000000000001
+		Right           0b0000000000000010
+		Bottom          0b0000000000000100
+		Left            0b0000000000001000
+
+		TopLeftEdge     0b0000000000010000
+		RightTopEdge    0b0000000000100000
+		BottomRightEdge 0b0000000001000000
+		LeftBottomEdge  0b0000000010000000
+
+		LeftTopEdge     0b0000000100000000
+		TopRightEdge    0b0000001000000000
+		RightBottomEdge 0b0000010000000000
+		BottomLeftEdge  0b0000100000000000
+
+		Center          0b0001000000000000
+		None            0b0000000000000000
+	*/
+
 	// limit rotations
 	rotations %= 4
-	var result = side
+	if rotations == 0 {
+		return side
+	}
+
+	// center doesn't rotate
+	hasCenter := side&Center != 0
+	result := side & ^Center
+
 	for rotations > 0 {
-		switch result {
-		case Top:
-			result = Right
-		case Right:
-			result = Bottom
-		case Left:
-			result = Top
-		case Bottom:
-			result = Left
+		result = result << 1
 
-		case TopLeftCorner:
-			result = TopRightCorner
-		case TopRightCorner:
-			result = BottomRightCorner
-		case BottomLeftCorner:
-			result = TopLeftCorner
-		case BottomRightCorner:
-			result = BottomLeftCorner
+		// loop the last 4 bits (rotated Left goes back into Top)
+		if result&0b1_0000 != 0 {
+			result &= ^(1 << 4) // clear the overflowed bit
+			result |= (1 << 0)  // set the bit in correct position
+		}
 
-		case TopLeftEdge:
-			result = RightTopEdge
-		case TopRightEdge:
-			result = RightBottomEdge
-		case RightTopEdge:
-			result = BottomRightEdge
-		case RightBottomEdge:
-			result = BottomLeftEdge
+		// loop the next 4 bits (rotated LeftBottomEdge goes back into TopLeftEdge)
+		if result&0b1_0000_0000 != 0 {
+			result &= ^(1 << 8) // clear the overflowed bit
+			result |= (1 << 4)  // set the bit in correct position
+		}
 
-		case LeftTopEdge:
-			result = TopRightEdge
-		case LeftBottomEdge:
-			result = TopLeftEdge
-		case BottomLeftEdge:
-			result = LeftTopEdge
-		case BottomRightEdge:
-			result = LeftBottomEdge
-
-		case Center:
-			result = Center
-		default:
-			result = None
+		// loop the next 4 bits (rotated BottomLeftEdge goes back into LeftTopEdge)
+		if result&0b1_0000_0000_0000 != 0 {
+			result &= ^(1 << 12) // clear the overflowed bit
+			result |= (1 << 8)   // set the bit in correct position
 		}
 		rotations--
 	}
-	return result
-}
 
-func RotateSideArray(sides []Side, rotations uint) []Side {
-	var rotatedSides []Side
-	for _, side := range sides {
-		rotatedSides = append(rotatedSides, side.Rotate(rotations))
+	if hasCenter {
+		result |= Center
 	}
-	return rotatedSides
+	return result
 }

--- a/pkg/tiles/side/side_test.go
+++ b/pkg/tiles/side/side_test.go
@@ -22,10 +22,6 @@ func TestSideRotate(t *testing.T) { //nolint:gocyclo // simply testing all state
 		t.Fatalf("got %#v should be %#v after rotation", Left.Rotate(1), Top)
 	}
 
-	if Center.Rotate(1) != Center {
-		t.Fatalf("got %#v should be %#v after rotation", Center.Rotate(1), Center)
-	}
-
 	if TopLeftEdge.Rotate(1) != RightTopEdge {
 		t.Fatalf("got %#v should be %#v after rotation", TopLeftEdge.Rotate(1), RightTopEdge)
 	}
@@ -86,10 +82,6 @@ func TestSideToString(t *testing.T) { //nolint:gocyclo // simply testing all sta
 
 	if Bottom.String() != "BOTTOM" {
 		t.Fatalf("got %#v should be %#v", Bottom.String(), "BOTTOM")
-	}
-
-	if Center.String() != "CENTER" {
-		t.Fatalf("got %#v should be %#v", Center.String(), "CENTER")
 	}
 
 	if TopLeftEdge.String() != "TOP_LEFT_EDGE" {

--- a/pkg/tiles/side/side_test.go
+++ b/pkg/tiles/side/side_test.go
@@ -21,22 +21,6 @@ func TestSideRotate(t *testing.T) { //nolint:gocyclo // simply testing all state
 	if Left.Rotate(1) != Top {
 		t.Fatalf("got %#v should be %#v after rotation", Left.Rotate(1), Top)
 	}
-	// corners
-	if TopLeftCorner.Rotate(1) != TopRightCorner {
-		t.Fatalf("got %#v should be %#v after rotation", TopLeftCorner.Rotate(1), TopRightCorner)
-	}
-
-	if TopRightCorner.Rotate(1) != BottomRightCorner {
-		t.Fatalf("got %#v should be %#v after rotation", TopRightCorner.Rotate(1), BottomRightCorner)
-	}
-
-	if BottomRightCorner.Rotate(1) != BottomLeftCorner {
-		t.Fatalf("got %#v should be %#v after rotation", BottomRightCorner.Rotate(1), BottomLeftCorner)
-	}
-
-	if BottomLeftCorner.Rotate(1) != TopLeftCorner {
-		t.Fatalf("got %#v should be %#v after rotation", BottomLeftCorner.Rotate(1), TopLeftCorner)
-	}
 
 	if Center.Rotate(1) != Center {
 		t.Fatalf("got %#v should be %#v after rotation", Center.Rotate(1), Center)
@@ -77,10 +61,6 @@ func TestSideRotate(t *testing.T) { //nolint:gocyclo // simply testing all state
 	if None.Rotate(1) != None {
 		t.Fatalf("got %#v should be %#v after rotation", None.Rotate(1), None)
 	}
-
-	if Side(80).Rotate(1) != None {
-		t.Fatalf("got %#v should be %#v after rotation", Side(80).Rotate(1), None)
-	}
 }
 
 func TestSideRotateReturnsSideRotatedTwice(t *testing.T) {
@@ -106,22 +86,6 @@ func TestSideToString(t *testing.T) { //nolint:gocyclo // simply testing all sta
 
 	if Bottom.String() != "BOTTOM" {
 		t.Fatalf("got %#v should be %#v", Bottom.String(), "BOTTOM")
-	}
-
-	if TopLeftCorner.String() != "TOP_LEFT_CORNER" {
-		t.Fatalf("got %#v should be %#v", TopLeftCorner.String(), "TOP_LEFT_CORNER")
-	}
-
-	if TopRightCorner.String() != "TOP_RIGHT_CORNER" {
-		t.Fatalf("got %#v should be %#v", TopRightCorner.String(), "TOP_RIGHT_CORNER")
-	}
-
-	if BottomLeftCorner.String() != "BOTTOM_LEFT_CORNER" {
-		t.Fatalf("got %#v should be %#v", BottomLeftCorner.String(), "BOTTOM_LEFT_CORNER")
-	}
-
-	if BottomRightCorner.String() != "BOTTOM_RIGHT_CORNER" {
-		t.Fatalf("got %#v should be %#v", BottomRightCorner.String(), "BOTTOM_RIGHT_CORNER")
 	}
 
 	if Center.String() != "CENTER" {
@@ -156,9 +120,4 @@ func TestSideToString(t *testing.T) { //nolint:gocyclo // simply testing all sta
 	if None.String() != "NONE" {
 		t.Fatalf("got %#v should be %#v", None.String(), "NONE")
 	}
-
-	if Side(20).String() != "ERROR" {
-		t.Fatalf("got %#v should be %#v", Side(20).String(), "ERROR")
-	}
-
 }

--- a/pkg/tiles/tile.go
+++ b/pkg/tiles/tile.go
@@ -3,7 +3,6 @@ package tiles
 import (
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/building"
 	featureMod "github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/feature"
-	sideMod "github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/side"
 )
 
 /*
@@ -29,7 +28,7 @@ outer:
 			continue
 		}
 		for i, feature := range tile.Features {
-			if !feature.Equals(rotated.Features[i]) {
+			if feature != rotated.Features[i] {
 				continue outer
 			}
 		}
@@ -77,12 +76,13 @@ func (tile Tile) Rotate(rotations uint) Tile {
 	var newFeatures []featureMod.Feature
 
 	for _, feature := range tile.Features {
-		var newSides []sideMod.Side
-		for _, side := range feature.Sides {
-			newSides = append(newSides, side.Rotate(rotations))
-		}
-
-		newFeatures = append(newFeatures, featureMod.Feature{FeatureType: feature.FeatureType, Sides: newSides})
+		newFeatures = append(
+			newFeatures,
+			featureMod.Feature{
+				FeatureType: feature.FeatureType,
+				Sides:       feature.Sides.Rotate(rotations),
+			},
+		)
 	}
 
 	tile.Features = newFeatures

--- a/pkg/tiles/tile_test.go
+++ b/pkg/tiles/tile_test.go
@@ -70,18 +70,18 @@ func TestTileEqualsReturnsTrueWhenEqualButRotated(t *testing.T) {
 
 func TestTileRotate(t *testing.T) {
 	var tile Tile
-	tile.Features = append(tile.Features, feature.Feature{FeatureType: feature.City, Sides: []side.Side{side.Top, side.Left}})
-	tile.Features = append(tile.Features, feature.Feature{FeatureType: feature.Road, Sides: []side.Side{side.Bottom, side.Right}})
-	tile.Features = append(tile.Features, feature.Feature{FeatureType: feature.Field, Sides: []side.Side{side.BottomRightEdge, side.RightBottomEdge}})
+	tile.Features = append(tile.Features, feature.Feature{FeatureType: feature.City, Sides: side.Top | side.Left})
+	tile.Features = append(tile.Features, feature.Feature{FeatureType: feature.Road, Sides: side.Bottom | side.Right})
+	tile.Features = append(tile.Features, feature.Feature{FeatureType: feature.Field, Sides: side.BottomRightEdge | side.RightBottomEdge})
 	tile.HasShield = true
 	tile.Building = building.None
 
 	var rotated = tile.Rotate(1)
 
 	var expected Tile
-	expected.Features = append(expected.Features, feature.Feature{FeatureType: feature.City, Sides: []side.Side{side.Right, side.Top}})
-	expected.Features = append(expected.Features, feature.Feature{FeatureType: feature.Road, Sides: []side.Side{side.Left, side.Bottom}})
-	expected.Features = append(expected.Features, feature.Feature{FeatureType: feature.Field, Sides: []side.Side{side.LeftBottomEdge, side.BottomLeftEdge}})
+	expected.Features = append(expected.Features, feature.Feature{FeatureType: feature.City, Sides: side.Right | side.Top})
+	expected.Features = append(expected.Features, feature.Feature{FeatureType: feature.Road, Sides: side.Left | side.Bottom})
+	expected.Features = append(expected.Features, feature.Feature{FeatureType: feature.Field, Sides: side.LeftBottomEdge | side.BottomLeftEdge})
 	expected.HasShield = true
 	expected.Building = building.None
 
@@ -92,27 +92,27 @@ func TestTileRotate(t *testing.T) {
 
 func TestTileFeatureGet(t *testing.T) {
 	var tile Tile
-	tile.Features = append(tile.Features, feature.Feature{FeatureType: feature.City, Sides: []side.Side{side.Top, side.Left}})
-	tile.Features = append(tile.Features, feature.Feature{FeatureType: feature.Road, Sides: []side.Side{side.Bottom, side.Right}})
-	tile.Features = append(tile.Features, feature.Feature{FeatureType: feature.Field, Sides: []side.Side{side.BottomRightEdge, side.RightBottomEdge}})
+	tile.Features = append(tile.Features, feature.Feature{FeatureType: feature.City, Sides: side.Top | side.Left})
+	tile.Features = append(tile.Features, feature.Feature{FeatureType: feature.Road, Sides: side.Bottom | side.Right})
+	tile.Features = append(tile.Features, feature.Feature{FeatureType: feature.Field, Sides: side.BottomRightEdge | side.RightBottomEdge})
 	tile.HasShield = true
 	tile.Building = building.None
 
 	var expectedCities = []feature.Feature{
 		{
-			FeatureType: feature.City, Sides: []side.Side{side.Top, side.Left},
+			FeatureType: feature.City, Sides: side.Top | side.Left,
 		},
 	}
 
 	var expectedRoads = []feature.Feature{
 		{
-			FeatureType: feature.Road, Sides: []side.Side{side.Bottom, side.Right},
+			FeatureType: feature.Road, Sides: side.Bottom | side.Right,
 		},
 	}
 
 	var expectedFields = []feature.Feature{
 		{
-			FeatureType: feature.Field, Sides: []side.Side{side.BottomRightEdge, side.RightBottomEdge},
+			FeatureType: feature.Field, Sides: side.BottomRightEdge | side.RightBottomEdge,
 		},
 	}
 

--- a/pkg/tiles/tiletemplates/tile_templates.go
+++ b/pkg/tiles/tiletemplates/tile_templates.go
@@ -12,19 +12,17 @@ func MonasteryWithoutRoads() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.TopLeftEdge,
-					side.TopRightEdge,
+				Sides: side.TopLeftEdge |
+					side.TopRightEdge |
 
-					side.RightTopEdge,
-					side.RightBottomEdge,
+					side.RightTopEdge |
+					side.RightBottomEdge |
 
-					side.LeftTopEdge,
-					side.LeftBottomEdge,
+					side.LeftTopEdge |
+					side.LeftBottomEdge |
 
-					side.BottomLeftEdge,
+					side.BottomLeftEdge |
 					side.BottomRightEdge,
-				},
 			},
 		},
 		HasShield: false,
@@ -40,26 +38,22 @@ func MonasteryWithSingleRoad() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-					side.Center,
+				Sides: side.Center |
 					side.Bottom,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.TopLeftEdge,
-					side.TopRightEdge,
+				Sides: side.TopLeftEdge |
+					side.TopRightEdge |
 
-					side.RightTopEdge,
-					side.RightBottomEdge,
+					side.RightTopEdge |
+					side.RightBottomEdge |
 
-					side.LeftTopEdge,
-					side.LeftBottomEdge,
+					side.LeftTopEdge |
+					side.LeftBottomEdge |
 
-					side.BottomLeftEdge,
+					side.BottomLeftEdge |
 					side.BottomRightEdge,
-				},
 			},
 		},
 		HasShield: false,
@@ -75,28 +69,22 @@ func StraightRoads() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-					side.Left,
+				Sides: side.Left |
 					side.Right,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftBottomEdge,
-					side.BottomLeftEdge,
-					side.BottomRightEdge,
+				Sides: side.LeftBottomEdge |
+					side.BottomLeftEdge |
+					side.BottomRightEdge |
 					side.RightBottomEdge,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftTopEdge,
-					side.TopLeftEdge,
-					side.TopRightEdge,
+				Sides: side.LeftTopEdge |
+					side.TopLeftEdge |
+					side.TopRightEdge |
 					side.RightTopEdge,
-				},
 			},
 		},
 		HasShield: false,
@@ -112,29 +100,23 @@ func RoadsTurn() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-					side.Left,
+				Sides: side.Left |
 					side.Bottom,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftBottomEdge,
+				Sides: side.LeftBottomEdge |
 					side.BottomLeftEdge,
-				},
 			},
 
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftTopEdge,
-					side.TopLeftEdge,
-					side.TopRightEdge,
-					side.RightTopEdge,
-					side.RightBottomEdge,
+				Sides: side.LeftTopEdge |
+					side.TopLeftEdge |
+					side.TopRightEdge |
+					side.RightTopEdge |
+					side.RightBottomEdge |
 					side.BottomRightEdge,
-				},
 			},
 		},
 		HasShield: false,
@@ -150,49 +132,36 @@ func TCrossRoad() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-					side.Left,
+				Sides: side.Left |
 					side.Center,
-				},
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-
-					side.Right,
+				Sides: side.Right |
 					side.Center,
-				},
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-					side.Bottom,
+				Sides: side.Bottom |
 					side.Center,
-				},
 			},
 
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftBottomEdge,
+				Sides: side.LeftBottomEdge |
 					side.BottomLeftEdge,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.RightBottomEdge,
+				Sides: side.RightBottomEdge |
 					side.BottomRightEdge,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftTopEdge,
-					side.TopLeftEdge,
-					side.TopRightEdge,
+				Sides: side.LeftTopEdge |
+					side.TopLeftEdge |
+					side.TopRightEdge |
 					side.RightTopEdge,
-				},
 			},
 		},
 		HasShield: false,
@@ -205,60 +174,43 @@ func XCrossRoad() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-					side.Left,
+				Sides: side.Left |
 					side.Center,
-				},
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-					side.Bottom,
+				Sides: side.Bottom |
 					side.Center,
-				},
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-					side.Right,
+				Sides: side.Right |
 					side.Center,
-				},
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-
-					side.Top,
+				Sides: side.Top |
 					side.Center,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftBottomEdge,
+				Sides: side.LeftBottomEdge |
 					side.BottomLeftEdge,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.RightBottomEdge,
+				Sides: side.RightBottomEdge |
 					side.BottomRightEdge,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftTopEdge,
+				Sides: side.LeftTopEdge |
 					side.TopLeftEdge,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.TopRightEdge,
+				Sides: side.TopRightEdge |
 					side.RightTopEdge,
-				},
 			},
 		},
 		HasShield: false,
@@ -274,20 +226,16 @@ func SingleCityEdgeNoRoads() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-					side.Top,
-				},
+				Sides:       side.Top,
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftTopEdge,
-					side.RightTopEdge,
-					side.RightBottomEdge,
-					side.BottomRightEdge,
-					side.LeftBottomEdge,
+				Sides: side.LeftTopEdge |
+					side.RightTopEdge |
+					side.RightBottomEdge |
+					side.BottomRightEdge |
+					side.LeftBottomEdge |
 					side.BottomLeftEdge,
-				},
 			},
 		},
 		HasShield: false,
@@ -303,33 +251,24 @@ func SingleCityEdgeStraightRoads() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-
-					side.Top,
-				},
+				Sides:       side.Top,
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-					side.Right,
+				Sides: side.Right |
 					side.Left,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.RightBottomEdge,
-					side.BottomRightEdge,
-					side.LeftBottomEdge,
+				Sides: side.RightBottomEdge |
+					side.BottomRightEdge |
+					side.LeftBottomEdge |
 					side.BottomLeftEdge,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftTopEdge,
+				Sides: side.LeftTopEdge |
 					side.RightTopEdge,
-				},
 			},
 		},
 		HasShield: false,
@@ -345,33 +284,24 @@ func SingleCityEdgeLeftRoadTurn() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-					side.Top,
-				},
+				Sides:       side.Top,
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-					side.Left,
+				Sides: side.Left |
 					side.Bottom,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.RightBottomEdge,
-					side.BottomRightEdge,
-					side.LeftTopEdge,
+				Sides: side.RightBottomEdge |
+					side.BottomRightEdge |
+					side.LeftTopEdge |
 					side.RightTopEdge,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-
-					side.BottomLeftEdge,
+				Sides: side.BottomLeftEdge |
 					side.LeftBottomEdge,
-				},
 			},
 		},
 		HasShield: false,
@@ -387,32 +317,24 @@ func SingleCityEdgeRightRoadTurn() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-					side.Top,
-				},
+				Sides:       side.Top,
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-					side.Right,
+				Sides: side.Right |
 					side.Bottom,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftTopEdge,
-					side.RightTopEdge,
-					side.BottomLeftEdge,
+				Sides: side.LeftTopEdge |
+					side.RightTopEdge |
+					side.BottomLeftEdge |
 					side.LeftBottomEdge,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.RightBottomEdge,
+				Sides: side.RightBottomEdge |
 					side.BottomRightEdge,
-				},
 			},
 		},
 		HasShield: false,
@@ -428,51 +350,37 @@ func SingleCityEdgeCrossRoad() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-					side.Top,
-				},
+				Sides:       side.Top,
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-					side.Right,
+				Sides: side.Right |
 					side.Center,
-				},
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-					side.Left,
+				Sides: side.Left |
 					side.Center,
-				},
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-					side.Bottom,
+				Sides: side.Bottom |
 					side.Center,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftTopEdge,
+				Sides: side.LeftTopEdge |
 					side.RightTopEdge,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.RightBottomEdge,
+				Sides: side.RightBottomEdge |
 					side.BottomRightEdge,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.BottomLeftEdge,
+				Sides: side.BottomLeftEdge |
 					side.LeftBottomEdge,
-				},
 			},
 		},
 		HasShield: false,
@@ -488,24 +396,18 @@ func TwoCityEdgesUpAndDownNotConnected() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-					side.Top,
-				},
+				Sides:       side.Top,
 			},
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-					side.Bottom,
-				},
+				Sides:       side.Bottom,
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftTopEdge,
-					side.RightTopEdge,
-					side.LeftBottomEdge,
+				Sides: side.LeftTopEdge |
+					side.RightTopEdge |
+					side.LeftBottomEdge |
 					side.RightBottomEdge,
-				},
 			},
 		},
 		HasShield: false,
@@ -521,24 +423,18 @@ func TwoCityEdgesCornerNotConnected() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-					side.Top,
-				},
+				Sides:       side.Top,
 			},
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-					side.Right,
-				},
+				Sides:       side.Right,
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftTopEdge,
-					side.LeftBottomEdge,
-					side.BottomLeftEdge,
+				Sides: side.LeftTopEdge |
+					side.LeftBottomEdge |
+					side.BottomLeftEdge |
 					side.BottomRightEdge,
-				},
 			},
 		},
 		HasShield: false,
@@ -554,25 +450,19 @@ func TwoCityEdgesUpAndDownConnected() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-					side.Top,
-					side.Bottom,
+				Sides: side.Top |
+					side.Bottom |
 					side.Center,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftTopEdge,
+				Sides: side.LeftTopEdge |
 					side.LeftBottomEdge,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.BottomLeftEdge,
+				Sides: side.BottomLeftEdge |
 					side.BottomRightEdge,
-				},
 			},
 		},
 		HasShield: false,
@@ -588,25 +478,19 @@ func TwoCityEdgesUpAndDownConnectedShield() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-					side.Top,
-					side.Bottom,
+				Sides: side.Top |
+					side.Bottom |
 					side.Center,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftTopEdge,
+				Sides: side.LeftTopEdge |
 					side.LeftBottomEdge,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.BottomLeftEdge,
+				Sides: side.BottomLeftEdge |
 					side.BottomRightEdge,
-				},
 			},
 		},
 		HasShield: true,
@@ -622,19 +506,15 @@ func TwoCityEdgesCornerConnected() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-					side.Top,
+				Sides: side.Top |
 					side.Right,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftTopEdge,
-					side.LeftBottomEdge,
-					side.BottomLeftEdge,
+				Sides: side.LeftTopEdge |
+					side.LeftBottomEdge |
+					side.BottomLeftEdge |
 					side.BottomRightEdge,
-				},
 			},
 		},
 		HasShield: false,
@@ -651,19 +531,15 @@ func TwoCityEdgesCornerConnectedShield() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-					side.Top,
+				Sides: side.Top |
 					side.Right,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftTopEdge,
-					side.LeftBottomEdge,
-					side.BottomLeftEdge,
+				Sides: side.LeftTopEdge |
+					side.LeftBottomEdge |
+					side.BottomLeftEdge |
 					side.BottomRightEdge,
-				},
 			},
 		},
 		HasShield: true,
@@ -679,31 +555,23 @@ func TwoCityEdgesCornerConnectedRoadTurn() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-					side.Top,
+				Sides: side.Top |
 					side.Right,
-				},
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-					side.Left,
+				Sides: side.Left |
 					side.Bottom,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftBottomEdge,
+				Sides: side.LeftBottomEdge |
 					side.BottomLeftEdge,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftTopEdge,
+				Sides: side.LeftTopEdge |
 					side.BottomRightEdge,
-				},
 			},
 		},
 		HasShield: false,
@@ -719,31 +587,23 @@ func TwoCityEdgesCornerConnectedRoadTurnShield() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-					side.Top,
+				Sides: side.Top |
 					side.Right,
-				},
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-					side.Left,
+				Sides: side.Left |
 					side.Bottom,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftBottomEdge,
+				Sides: side.LeftBottomEdge |
 					side.BottomLeftEdge,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftTopEdge,
+				Sides: side.LeftTopEdge |
 					side.BottomRightEdge,
-				},
 			},
 		},
 		HasShield: true,
@@ -759,19 +619,15 @@ func ThreeCityEdgesConnected() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-					side.Top,
-					side.Right,
-					side.Center,
+				Sides: side.Top |
+					side.Right |
+					side.Center |
 					side.Left,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftBottomEdge,
+				Sides: side.LeftBottomEdge |
 					side.BottomLeftEdge,
-				},
 			},
 		},
 		HasShield: false,
@@ -787,19 +643,15 @@ func ThreeCityEdgesConnectedShield() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-					side.Top,
-					side.Right,
-					side.Center,
+				Sides: side.Top |
+					side.Right |
+					side.Center |
 					side.Left,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftBottomEdge,
+				Sides: side.LeftBottomEdge |
 					side.BottomLeftEdge,
-				},
 			},
 		},
 		HasShield: true,
@@ -815,31 +667,23 @@ func ThreeCityEdgesConnectedRoad() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-					side.Top,
-					side.Right,
-					side.Center,
+				Sides: side.Top |
+					side.Right |
+					side.Center |
 					side.Left,
-				},
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-					side.Center,
+				Sides: side.Center |
 					side.Bottom,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftBottomEdge,
-				},
+				Sides:       side.LeftBottomEdge,
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.BottomLeftEdge,
-				},
+				Sides:       side.BottomLeftEdge,
 			},
 		},
 		HasShield: false,
@@ -855,31 +699,23 @@ func ThreeCityEdgesConnectedRoadShield() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-					side.Top,
-					side.Right,
-					side.Center,
+				Sides: side.Top |
+					side.Right |
+					side.Center |
 					side.Left,
-				},
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: []side.Side{
-					side.Center,
+				Sides: side.Center |
 					side.Bottom,
-				},
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.LeftBottomEdge,
-				},
+				Sides:       side.LeftBottomEdge,
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: []side.Side{
-					side.BottomLeftEdge,
-				},
+				Sides:       side.BottomLeftEdge,
 			},
 		},
 		HasShield: true,
@@ -895,13 +731,11 @@ func FourCityEdgesConnectedShield() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.City,
-				Sides: []side.Side{
-					side.Top,
-					side.Right,
-					side.Center,
-					side.Left,
+				Sides: side.Top |
+					side.Right |
+					side.Center |
+					side.Left |
 					side.Bottom,
-				},
 			},
 		},
 		HasShield: true,

--- a/pkg/tiles/tiletemplates/tile_templates.go
+++ b/pkg/tiles/tiletemplates/tile_templates.go
@@ -38,8 +38,7 @@ func MonasteryWithSingleRoad() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.Road,
-				Sides: side.Center |
-					side.Bottom,
+				Sides:       side.Bottom,
 			},
 			{
 				FeatureType: feature.Field,
@@ -132,18 +131,15 @@ func TCrossRoad() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.Road,
-				Sides: side.Left |
-					side.Center,
+				Sides:       side.Left,
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: side.Right |
-					side.Center,
+				Sides:       side.Right,
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: side.Bottom |
-					side.Center,
+				Sides:       side.Bottom,
 			},
 
 			{
@@ -174,23 +170,19 @@ func XCrossRoad() tiles.Tile {
 		Features: []feature.Feature{
 			{
 				FeatureType: feature.Road,
-				Sides: side.Left |
-					side.Center,
+				Sides:       side.Left,
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: side.Bottom |
-					side.Center,
+				Sides:       side.Bottom,
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: side.Right |
-					side.Center,
+				Sides:       side.Right,
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: side.Top |
-					side.Center,
+				Sides:       side.Top,
 			},
 			{
 				FeatureType: feature.Field,
@@ -354,18 +346,15 @@ func SingleCityEdgeCrossRoad() tiles.Tile {
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: side.Right |
-					side.Center,
+				Sides:       side.Right,
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: side.Left |
-					side.Center,
+				Sides:       side.Left,
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: side.Bottom |
-					side.Center,
+				Sides:       side.Bottom,
 			},
 			{
 				FeatureType: feature.Field,
@@ -451,8 +440,7 @@ func TwoCityEdgesUpAndDownConnected() tiles.Tile {
 			{
 				FeatureType: feature.City,
 				Sides: side.Top |
-					side.Bottom |
-					side.Center,
+					side.Bottom,
 			},
 			{
 				FeatureType: feature.Field,
@@ -479,8 +467,7 @@ func TwoCityEdgesUpAndDownConnectedShield() tiles.Tile {
 			{
 				FeatureType: feature.City,
 				Sides: side.Top |
-					side.Bottom |
-					side.Center,
+					side.Bottom,
 			},
 			{
 				FeatureType: feature.Field,
@@ -621,7 +608,6 @@ func ThreeCityEdgesConnected() tiles.Tile {
 				FeatureType: feature.City,
 				Sides: side.Top |
 					side.Right |
-					side.Center |
 					side.Left,
 			},
 			{
@@ -645,7 +631,6 @@ func ThreeCityEdgesConnectedShield() tiles.Tile {
 				FeatureType: feature.City,
 				Sides: side.Top |
 					side.Right |
-					side.Center |
 					side.Left,
 			},
 			{
@@ -669,13 +654,11 @@ func ThreeCityEdgesConnectedRoad() tiles.Tile {
 				FeatureType: feature.City,
 				Sides: side.Top |
 					side.Right |
-					side.Center |
 					side.Left,
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: side.Center |
-					side.Bottom,
+				Sides:       side.Bottom,
 			},
 			{
 				FeatureType: feature.Field,
@@ -701,13 +684,11 @@ func ThreeCityEdgesConnectedRoadShield() tiles.Tile {
 				FeatureType: feature.City,
 				Sides: side.Top |
 					side.Right |
-					side.Center |
 					side.Left,
 			},
 			{
 				FeatureType: feature.Road,
-				Sides: side.Center |
-					side.Bottom,
+				Sides:       side.Bottom,
 			},
 			{
 				FeatureType: feature.Field,
@@ -733,7 +714,6 @@ func FourCityEdgesConnectedShield() tiles.Tile {
 				FeatureType: feature.City,
 				Sides: side.Top |
 					side.Right |
-					side.Center |
 					side.Left |
 					side.Bottom,
 			},


### PR DESCRIPTION
Replaced Side values to be a bitmask instead of plain enum. Also removed corners from Side, as they were not going to be used and Center Side, as it is not strictly necessary.
The side values currently are as follows:
```
TopLeftEdge     0b10000000
TopRightEdge    0b01000000

RightTopEdge    0b00100000
RightBottomEdge 0b00010000

BottomRightEdge 0b00001000
BottomLeftEdge  0b00000100

LeftBottomEdge  0b00000010
LeftTopEdge     0b00000001

Top             0b11000000
Right           0b00110000
Bottom          0b00001100
Left            0b00000011

None            0b00000000
```
Rotating the tile has been greatly simplified to use just circular bitshift (aka bitwise rotation) by {2*rotation} bits to the right. (Only the internals of the Rotate function have changed)

Features with multiple sides now use for example `Top | Right` instead of a slice.
Also `Top` is now equal to `TopLeftEdge | TopRightEdge`, etc.

Benefits of this change:
- all features always have the same size (no variable-sized slices)
- features can be compared directly, without the .Equals() method
- faster rotation and comparison (probably, I didn't actually check this :P)
- features can be now used as keys in maps - this is the most important one