### PR TITLE
Implement checking whether tile (including meeples) can be placed

### DIFF
--- a/pkg/engine/requests_test.go
+++ b/pkg/engine/requests_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/game"
+	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/game/elements"
+	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/game/position"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/tiletemplates"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tilesets"
@@ -180,22 +182,35 @@ func TestGameEngineSendGetLegalMovesBatchReturnsNoDuplicates(t *testing.T) {
 	}
 
 	// Monastery with no roads is symmetrical both horizontally and vertically
-	if len(resp.Moves) != 1 {
-		t.Fatalf("expected %v as number of available moves, got %v instead", 1, resp.Moves)
+	// and there's just one valid position (below starting tile, i.e. (0, -1))
+	// so there's three legal moves: without meeple and with meeple on each of
+	// the 2 features
+
+	// without meeple
+	ptile1 := elements.ToPlacedTile(tile)
+	ptile1.Position = position.New(0, -1)
+	// with meeple on the field
+	ptile2 := elements.ToPlacedTile(tile)
+	ptile2.Position = position.New(0, -1)
+	ptile2.Features[0].Meeple = elements.Meeple{
+		Type:     elements.NormalMeeple,
+		PlayerID: elements.ID(1),
 	}
-	if resp.Moves[0].Move.Position.X() != 0 {
-		t.Fatalf("expected %v X, got %v instead", 0, resp.Moves[0].Move.Position.X())
+	// with meeple on the monastery
+	ptile3 := elements.ToPlacedTile(tile)
+	ptile3.Position = position.New(0, -1)
+	ptile3.Features[1].Meeple = elements.Meeple{
+		Type:     elements.NormalMeeple,
+		PlayerID: elements.ID(1),
 	}
-	if resp.Moves[0].Move.Position.Y() != -1 {
-		t.Fatalf("expected %v Y, got %v instead", -1, resp.Moves[0].Move.Position.Y())
+	expectedMoves := []elements.PlacedTile{ptile1, ptile2, ptile3}
+
+	actualMoves := make([]elements.PlacedTile, len(resp.Moves))
+	for i, moveWithState := range resp.Moves {
+		actualMoves[i] = moveWithState.Move
 	}
-	if len(resp.Moves[0].Move.Features) != len(tile.Features) {
-		t.Fatalf("expected %#v, got %#v instead", tile.Features, resp.Moves[0].Move.Features)
-	}
-	for i := range tile.Features {
-		if !tile.Features[i].Equals(resp.Moves[0].Move.Features[i].Feature) {
-			t.Fatalf("expected %#v to equal %#v", tile.Features, resp.Moves[0].Move.Features)
-		}
+	if !reflect.DeepEqual(expectedMoves, actualMoves) {
+		t.Fatalf("expected following moves: %#v, got %#v instead", expectedMoves, actualMoves)
 	}
 
 	engine.Close()
@@ -232,8 +247,7 @@ func TestGameEngineSendGetLegalMovesBatchReturnsAllLegalRotations(t *testing.T) 
 	// - meeple on monastery
 	// - meeple on field
 	// - meeple on road
-	// For now, meeple placement is not handled so last number is 1 instead of 4 below
-	expectedMoveCount := 1 * 3 * 1
+	expectedMoveCount := 1 * 3 * 4
 	if len(resp.Moves) != expectedMoveCount {
 		t.Fatalf("expected %v as number of available moves, got %v instead", expectedMoveCount, resp.Moves)
 	}
@@ -255,15 +269,19 @@ func TestGameEngineSendGetLegalMovesBatchReturnsAllLegalRotations(t *testing.T) 
 		// road on the right
 		tile.Rotate(3),
 	}
-	for i, moveState := range resp.Moves {
-		expected := expectedTiles[i]
-		if len(moveState.Move.Features) != len(expected.Features) {
-			t.Fatalf("expected %#v, got %#v instead", expected, moveState)
-		}
-		for i := range expected.Features {
-			if !expected.Features[i].Equals(moveState.Move.Features[i].Feature) {
-				t.Fatalf("expected %#v to equal %#v", expected, moveState)
+	moveIndex := 0
+	for _, expected := range expectedTiles {
+		for range 4 {
+			moveState := resp.Moves[moveIndex]
+			for i := range expected.Features {
+				if len(moveState.Move.Features) != len(expected.Features) {
+					t.Fatalf("expected %#v, got %#v instead", moveState, expected)
+				}
+				if !expected.Features[i].Equals(moveState.Move.Features[i].Feature) {
+					t.Fatalf("expected %#v to equal %#v", moveState, expected)
+				}
 			}
+			moveIndex++
 		}
 	}
 

--- a/pkg/game/board.go
+++ b/pkg/game/board.go
@@ -180,7 +180,8 @@ func (board *board) isPositionValid(tile elements.PlacedTile) bool {
 }
 
 func (board *board) CanBePlaced(tile elements.PlacedTile) bool {
-	return board.TileHasValidPlacement(elements.ToTile(tile)) &&
+	return board.isPositionValid(tile) &&
+		slices.Contains(board.placeablePositions, tile.Position) &&
 		// TODO: since `tile` can be user input, we need to check
 		// that legal number of meeples (i.e. just one) has been placed
 		board.cityCanBePlaced(tile) &&

--- a/pkg/game/board.go
+++ b/pkg/game/board.go
@@ -269,9 +269,11 @@ func (board *board) PlaceTile(tile elements.PlacedTile) (elements.ScoreReport, e
 			"Board's tiles capacity exceeded, logic error?",
 		)
 	}
-	// TODO for future tasks:
-	// - determine if the tile can placed at a given position,
-	//   or return ErrInvalidMove otherwise
+
+	if !board.CanBePlaced(tile) {
+		return elements.ScoreReport{}, elements.ErrInvalidPosition
+	}
+
 	setTiles := board.tileSet.Tiles
 	actualIndex := 1
 	for {

--- a/pkg/game/board.go
+++ b/pkg/game/board.go
@@ -172,11 +172,34 @@ func (board *board) isPositionValid(tile elements.PlacedTile) bool {
 	return true
 }
 
-//revive:disable-next-line:unused-parameter Until the TODO is finished.
 func (board *board) CanBePlaced(tile elements.PlacedTile) bool {
-	// TODO for future tasks:
-	// - implement generation of legal moves
-	// - to be implemented after #18, #19 and #20 to avoid code duplication
+	return board.TileHasValidPlacement(elements.ToTile(tile)) &&
+		board.cityCanBePlaced(tile) &&
+		board.fieldCanBePlaced(tile) &&
+		board.monasteryCanBePlaced(tile) &&
+		board.roadCanBePlaced(tile)
+}
+
+//revive:disable-next-line:unused-parameter Until the TODO is finished.
+func (board *board) cityCanBePlaced(tile elements.PlacedTile) bool {
+	// TODO: implement validity of meeple placement
+	return true
+}
+
+//revive:disable-next-line:unused-parameter Until the TODO is finished.
+func (board *board) fieldCanBePlaced(tile elements.PlacedTile) bool {
+	// TODO: implement validity of meeple placement
+	return true
+}
+
+func (board *board) monasteryCanBePlaced(_ elements.PlacedTile) bool {
+	// meeple can always be placed on a monastery
+	return true
+}
+
+//revive:disable-next-line:unused-parameter Until the TODO is finished.
+func (board *board) roadCanBePlaced(tile elements.PlacedTile) bool {
+	// TODO: implement validity of meeple placement
 	return true
 }
 

--- a/pkg/game/board.go
+++ b/pkg/game/board.go
@@ -237,8 +237,8 @@ func (board *board) fieldCanBePlaced(tile elements.PlacedTile) bool {
 		// unset the Meeple in our copy of the feature
 		feat.Meeple = elements.Meeple{}
 
-		// TODO: potential problem: Field instance cannot expand to another feature
-		// on the tile checked by this method since it's not part of the board.
+		// TODO: Field instance cannot expand to another feature on the tile checked by
+		// this method since it's not part of the board. See GH-86.
 		field := field.New(feat, tile.Position)
 		field.Expand(board, board.cityManager)
 

--- a/pkg/game/board.go
+++ b/pkg/game/board.go
@@ -180,10 +180,8 @@ func (board *board) CanBePlaced(tile elements.PlacedTile) bool {
 		board.roadCanBePlaced(tile)
 }
 
-//revive:disable-next-line:unused-parameter Until the TODO is finished.
 func (board *board) cityCanBePlaced(tile elements.PlacedTile) bool {
-	// TODO: implement validity of meeple placement
-	return true
+	return board.cityManager.CanBePlaced(tile)
 }
 
 //revive:disable-next-line:unused-parameter Until the TODO is finished.

--- a/pkg/game/board.go
+++ b/pkg/game/board.go
@@ -181,6 +181,8 @@ func (board *board) isPositionValid(tile elements.PlacedTile) bool {
 
 func (board *board) CanBePlaced(tile elements.PlacedTile) bool {
 	return board.TileHasValidPlacement(elements.ToTile(tile)) &&
+		// TODO: since `tile` can be user input, we need to check
+		// that legal number of meeples (i.e. just one) has been placed
 		board.cityCanBePlaced(tile) &&
 		board.fieldCanBePlaced(tile) &&
 		board.monasteryCanBePlaced(tile) &&

--- a/pkg/game/board.go
+++ b/pkg/game/board.go
@@ -117,11 +117,18 @@ func (board *board) TileHasValidPlacement(tile tiles.Tile) bool {
 	return false
 }
 
-func (board *board) GetLegalMovesFor(placement elements.PlacedTile) []elements.PlacedTile {
+func (board *board) GetLegalMovesFor(basePlacement elements.PlacedTile) []elements.PlacedTile {
 	// create initial move list without any meeple placed
-	moves := []elements.PlacedTile{placement}
-	// TODO:
-	// - implement generation of legal moves *with* meeples
+	moves := []elements.PlacedTile{basePlacement}
+	meepleTypes := []elements.MeepleType{elements.NormalMeeple}
+	for i := range basePlacement.Features {
+		for _, meepleType := range meepleTypes {
+			placement := basePlacement
+			placement.Features = slices.Clone(basePlacement.Features)
+			placement.Features[i].Meeple = elements.Meeple{Type: meepleType}
+			moves = append(moves, placement)
+		}
+	}
 	return moves
 }
 

--- a/pkg/game/board.go
+++ b/pkg/game/board.go
@@ -192,28 +192,32 @@ func (board *board) cityCanBePlaced(tile elements.PlacedTile) bool {
 }
 
 func (board *board) fieldCanBePlaced(tile elements.PlacedTile) bool {
-	if !tile.HasMeeple() {
-		return true
-	}
-
+	// While placing a tile, the player can only put a single meeple on a field.
+	// This means we don't have to care about whether our field expands into
+	// a different feature on our tile - we will only expand the feature
+	// if it has a meeple and that only happens once.
 	for _, feat := range tile.Features {
 		if feat.FeatureType != feature.Field || feat.Meeple.Type == elements.NoneMeeple {
 			continue
 		}
+
+		// unset the Meeple in our copy of the feature
+		feat.Meeple = elements.Meeple{}
+
+		// TODO: potential problem: Field instance cannot expand to another feature
+		// on the tile checked by this method since it's not part of the board.
 		field := field.New(feat, tile.Position)
 		field.Expand(board, board.cityManager)
 
 		// score report function checks the whole field for placed meeples
 		// and reports any meeples that would be returned which we can use here
 		scoreReport := field.GetScoreReport()
-
-		fieldMeepleCount := 0
-		for _, returnedMeeples := range scoreReport.ReturnedMeeples {
-			fieldMeepleCount += len(returnedMeeples)
-		}
-		if fieldMeepleCount > 1 { // one meeple is okay, as it can be the one we just placed
+		if len(scoreReport.ReturnedMeeples) != 0 {
 			return false
 		}
+
+		// a single tile can only have one meeple on a field
+		break
 	}
 	return true
 }

--- a/pkg/game/board.go
+++ b/pkg/game/board.go
@@ -184,9 +184,28 @@ func (board *board) cityCanBePlaced(tile elements.PlacedTile) bool {
 	return board.cityManager.CanBePlaced(tile)
 }
 
-//revive:disable-next-line:unused-parameter Until the TODO is finished.
 func (board *board) fieldCanBePlaced(tile elements.PlacedTile) bool {
-	// TODO: implement validity of meeple placement
+	if true {
+		return true
+	}
+
+	// TODO: figure out how to implement this properly
+	// - there can be multiple field features that could expand into one
+	//   but there doesn't seem to be a good way to detect this
+	for _, feat := range tile.Features {
+		if feat.FeatureType != feature.Field {
+			continue
+		}
+		field := field.New(feat, tile.Position)
+		field.Expand(board, board.cityManager)
+
+		// score report function checks the whole field for placed meeples
+		// and reports any meeples that would be returned which we can use here
+		scoreReport := field.GetScoreReport()
+		if len(scoreReport.ReturnedMeeples) != 0 {
+			return false
+		}
+	}
 	return true
 }
 

--- a/pkg/game/board.go
+++ b/pkg/game/board.go
@@ -192,15 +192,12 @@ func (board *board) cityCanBePlaced(tile elements.PlacedTile) bool {
 }
 
 func (board *board) fieldCanBePlaced(tile elements.PlacedTile) bool {
-	if true {
+	if !tile.HasMeeple() {
 		return true
 	}
 
-	// TODO: figure out how to implement this properly
-	// - there can be multiple field features that could expand into one
-	//   but there doesn't seem to be a good way to detect this
 	for _, feat := range tile.Features {
-		if feat.FeatureType != feature.Field {
+		if feat.FeatureType != feature.Field || feat.Meeple.Type == elements.NoneMeeple {
 			continue
 		}
 		field := field.New(feat, tile.Position)
@@ -209,7 +206,12 @@ func (board *board) fieldCanBePlaced(tile elements.PlacedTile) bool {
 		// score report function checks the whole field for placed meeples
 		// and reports any meeples that would be returned which we can use here
 		scoreReport := field.GetScoreReport()
-		if len(scoreReport.ReturnedMeeples) != 0 {
+
+		fieldMeepleCount := 0
+		for _, returnedMeeples := range scoreReport.ReturnedMeeples {
+			fieldMeepleCount += len(returnedMeeples)
+		}
+		if fieldMeepleCount > 1 { // one meeple is okay, as it can be the one we just placed
 			return false
 		}
 	}

--- a/pkg/game/board_test.go
+++ b/pkg/game/board_test.go
@@ -243,7 +243,7 @@ func TestIsPositionValidWhenPositionIsValid(t *testing.T) {
 	}
 }
 
-func TestBoardScoreInclompleteMonastery(t *testing.T) {
+func TestBoardScoreIncompleteMonastery(t *testing.T) {
 	var report elements.ScoreReport
 	var extendedTileSet = tilesets.StandardTileSet()
 	for range 3 {
@@ -264,10 +264,10 @@ func TestBoardScoreInclompleteMonastery(t *testing.T) {
 	tiles[0].Monastery().Meeple.Type = elements.NormalMeeple
 
 	// set positions
-	tiles[0].Position = position.New(0, 1)
-	tiles[1].Position = position.New(1, 1)
-	tiles[2].Position = position.New(0, 2)
-	tiles[3].Position = position.New(1, 2)
+	tiles[0].Position = position.New(0, -1)
+	tiles[1].Position = position.New(1, -1)
+	tiles[2].Position = position.New(0, -2)
+	tiles[3].Position = position.New(1, -2)
 
 	// place tiles
 	for i, tile := range tiles {
@@ -292,7 +292,7 @@ func TestBoardScoreInclompleteMonastery(t *testing.T) {
 	expectedReport.ReturnedMeeples = map[elements.ID][]elements.MeepleWithPosition{
 		1: {elements.NewMeepleWithPosition(
 			elements.Meeple{Type: elements.NormalMeeple, PlayerID: elements.ID(1)},
-			position.New(0, 1),
+			position.New(0, -1),
 		)},
 	}
 
@@ -304,17 +304,17 @@ func TestBoardScoreInclompleteMonastery(t *testing.T) {
 func TestBoardCompleteTwoMonasteriesAtOnce(t *testing.T) {
 	/*
 		the board setup is as follows:
+		 S
 		FFFF
 		FMMF
 		FFFF
-		 S
 
 		F - field
 		M - monastery
 		S - starting tile
 
-		left monastery is at (0,2)
-		right monastery is at (1,2)
+		left monastery is at (0,-2)
+		right monastery is at (1,-2)
 		right monastery is placed as the last tile
 	*/
 
@@ -349,23 +349,23 @@ func TestBoardCompleteTwoMonasteriesAtOnce(t *testing.T) {
 	tiles[11].Monastery().Meeple.Type = elements.NormalMeeple
 
 	// set positions
-	tiles[0].Position = position.New(0, 1)
-	tiles[1].Position = position.New(0, 2)
-	tiles[2].Position = position.New(0, 3)
+	tiles[0].Position = position.New(0, -1)
+	tiles[1].Position = position.New(0, -2)
+	tiles[2].Position = position.New(0, -3)
 
-	tiles[3].Position = position.New(-1, 1)
-	tiles[4].Position = position.New(-1, 2)
-	tiles[5].Position = position.New(-1, 3)
+	tiles[3].Position = position.New(-1, -1)
+	tiles[4].Position = position.New(-1, -2)
+	tiles[5].Position = position.New(-1, -3)
 
-	tiles[6].Position = position.New(1, 1)
+	tiles[6].Position = position.New(1, -1)
 
-	tiles[7].Position = position.New(2, 1)
-	tiles[8].Position = position.New(2, 2)
-	tiles[9].Position = position.New(2, 3)
+	tiles[7].Position = position.New(2, -1)
+	tiles[8].Position = position.New(2, -2)
+	tiles[9].Position = position.New(2, -3)
 
-	tiles[10].Position = position.New(1, 3)
+	tiles[10].Position = position.New(1, -3)
 
-	tiles[11].Position = position.New(1, 2)
+	tiles[11].Position = position.New(1, -2)
 
 	// place tiles
 	for i, tile := range tiles[:len(tiles)-1] {
@@ -394,11 +394,11 @@ func TestBoardCompleteTwoMonasteriesAtOnce(t *testing.T) {
 	expectedReport.ReturnedMeeples = map[elements.ID][]elements.MeepleWithPosition{
 		1: {elements.NewMeepleWithPosition(
 			elements.Meeple{Type: elements.NormalMeeple, PlayerID: elements.ID(1)},
-			position.New(0, 2),
+			position.New(0, -2),
 		)},
 		2: {elements.NewMeepleWithPosition(
 			elements.Meeple{Type: elements.NormalMeeple, PlayerID: elements.ID(2)},
-			position.New(1, 2),
+			position.New(1, -2),
 		)},
 	}
 	if !reflect.DeepEqual(report, expectedReport) {

--- a/pkg/game/board_test.go
+++ b/pkg/game/board_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/game/position"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/game/test"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles"
+	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/feature"
+	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/side"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/tiletemplates"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tilesets"
 )
@@ -126,6 +128,48 @@ func TestBoardCanBePlacedReturnsFalseWhenMultipleFeaturesHaveMeeples(t *testing.
 
 	expected := false
 	actual := board.CanBePlaced(ptile)
+
+	if expected != actual {
+		t.Fatalf("expected %#v, got %#v instead", expected, actual)
+	}
+}
+
+func TestBoardFieldCanBePlacedReturnsFalseWhenExpandToFieldWithMeepleHappensOverAnotherField(t *testing.T) {
+	t.Skip("not implemented yet, see GH-86")
+
+	board := NewBoard(tilesets.StandardTileSet()).(*board)
+
+	// prepare board layout (graphical representation can be found in GH-86)
+	tilesToPlace := []elements.PlacedTile{}
+	ptile := elements.ToPlacedTile(tiletemplates.SingleCityEdgeNoRoads().Rotate(2))
+	ptile.Position = position.New(0, 1)
+	ptile.GetPlacedFeatureAtSide(side.Bottom, feature.City).Meeple = elements.Meeple{
+		Type: elements.NormalMeeple, PlayerID: 1,
+	}
+	tilesToPlace = append(tilesToPlace, ptile)
+
+	ptile = elements.ToPlacedTile(tiletemplates.StraightRoads().Rotate(1))
+	ptile.Position = position.New(1, 1)
+	tilesToPlace = append(tilesToPlace, ptile)
+
+	ptile = elements.ToPlacedTile(tiletemplates.MonasteryWithSingleRoad().Rotate(3))
+	ptile.Position = position.New(-1, 0)
+	tilesToPlace = append(tilesToPlace, ptile)
+
+	for _, ptile := range tilesToPlace {
+		if _, err := board.PlaceTile(ptile); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ptile = elements.ToPlacedTile(tiletemplates.RoadsTurn().Rotate(1))
+	ptile.Position = position.New(1, 0)
+	ptile.GetPlacedFeatureAtSide(side.Right, feature.Field).Meeple = elements.Meeple{
+		Type: elements.NormalMeeple, PlayerID: 2,
+	}
+
+	expected := false
+	actual := board.fieldCanBePlaced(ptile)
 
 	if expected != actual {
 		t.Fatalf("expected %#v, got %#v instead", expected, actual)

--- a/pkg/game/board_test.go
+++ b/pkg/game/board_test.go
@@ -117,6 +117,21 @@ func TestBoardCanBePlacedReturnsTrueWhenPlacedTileCanBePlaced(t *testing.T) {
 	}
 }
 
+func TestBoardCanBePlacedReturnsFalseWhenMultipleFeaturesHaveMeeples(t *testing.T) {
+	board := NewBoard(tilesets.StandardTileSet())
+	ptile := elements.ToPlacedTile(tiletemplates.SingleCityEdgeNoRoads().Rotate(2))
+	ptile.Position = position.New(0, 1)
+	ptile.Features[0].Meeple = elements.Meeple{Type: elements.NormalMeeple, PlayerID: 1}
+	ptile.Features[1].Meeple = elements.Meeple{Type: elements.NormalMeeple, PlayerID: 1}
+
+	expected := false
+	actual := board.CanBePlaced(ptile)
+
+	if expected != actual {
+		t.Fatalf("expected %#v, got %#v instead", expected, actual)
+	}
+}
+
 func TestBoardPlaceTileErrorsWhenCapacityIsExceeded(t *testing.T) {
 	tileSet := tilesets.StandardTileSet()
 	tileSet.Tiles = []tiles.Tile{}

--- a/pkg/game/board_test.go
+++ b/pkg/game/board_test.go
@@ -175,7 +175,7 @@ func TestBoardFieldCanBePlacedReturnsFalseWhenExpandToFieldWithMeepleHappensOver
 	tilesToPlace := []elements.PlacedTile{}
 	ptile := elements.ToPlacedTile(tiletemplates.SingleCityEdgeNoRoads().Rotate(2))
 	ptile.Position = position.New(0, 1)
-	ptile.GetPlacedFeatureAtSide(side.Bottom, feature.City).Meeple = elements.Meeple{
+	ptile.GetPlacedFeatureAtSide(side.Top, feature.Field).Meeple = elements.Meeple{
 		Type: elements.NormalMeeple, PlayerID: 1,
 	}
 	tilesToPlace = append(tilesToPlace, ptile)

--- a/pkg/game/board_test.go
+++ b/pkg/game/board_test.go
@@ -166,6 +166,19 @@ func TestBoardCanBePlacedReturnsFalseWhenMultipleFeaturesHaveMeeples(t *testing.
 	}
 }
 
+func TestBoardCanBePlacedReturnsFalseWhenPlacingAtInvalidPosition(t *testing.T) {
+	board := NewBoard(tilesets.StandardTileSet())
+	ptile := elements.ToPlacedTile(tiletemplates.SingleCityEdgeNoRoads().Rotate(2))
+	ptile.Position = position.New(0, 2)
+
+	expected := false
+	actual := board.CanBePlaced(ptile)
+
+	if expected != actual {
+		t.Fatalf("expected %#v, got %#v instead", expected, actual)
+	}
+}
+
 func TestBoardFieldCanBePlacedReturnsFalseWhenExpandToFieldWithMeepleHappensOverAnotherField(t *testing.T) {
 	t.Skip("not implemented yet, see GH-86")
 

--- a/pkg/game/board_test.go
+++ b/pkg/game/board_test.go
@@ -209,12 +209,13 @@ func TestBoardFieldCanBePlacedReturnsFalseWhenExpandToFieldWithMeepleHappensOver
 
 	ptile = elements.ToPlacedTile(tiletemplates.RoadsTurn().Rotate(1))
 	ptile.Position = position.New(1, 0)
-	ptile.GetPlacedFeatureAtSide(side.Right, feature.Field).Meeple = elements.Meeple{
+	feat := ptile.GetPlacedFeatureAtSide(side.Right, feature.Field)
+	feat.Meeple = elements.Meeple{
 		Type: elements.NormalMeeple, PlayerID: 2,
 	}
 
 	expected := false
-	actual := board.fieldCanBePlaced(ptile)
+	actual := board.fieldCanBePlaced(ptile, *feat)
 
 	if expected != actual {
 		t.Fatalf("expected %#v, got %#v instead", expected, actual)

--- a/pkg/game/can_be_placed_test.go
+++ b/pkg/game/can_be_placed_test.go
@@ -1,0 +1,133 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/game/elements"
+	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/game/position"
+	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/feature"
+	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/side"
+	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/tiletemplates"
+	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tilesets"
+)
+
+func TestPlaceFieldDirectlyAdjacentToCity(t *testing.T) {
+	/*
+		the board setup is as follows:
+		M
+		S
+
+		S - starting tile
+		M - monastery with a single road, going left
+
+		The top edge of the city directly neighbours the field (invalid placement)
+	*/
+	boardInterface := NewBoard(tilesets.StandardTileSet())
+	board := boardInterface.(*board)
+
+	tiles := []elements.PlacedTile{
+		elements.ToPlacedTile(tiletemplates.MonasteryWithSingleRoad().Rotate(1)),
+	}
+
+	// set positions
+	tiles[0].Position = position.New(0, 1)
+
+	_, err := board.PlaceTile(tiles[0])
+	if err == nil {
+		t.Fatalf("expected error placing first tile")
+	}
+}
+
+func TestPlaceTwoAdjacentFieldsWithMeeples(t *testing.T) {
+	/*
+		the board setup is as follows:
+		S
+		M
+		M
+
+		S - starting tile
+		M - monastery with a single road, going left
+
+		The meeples are placed on both monasteries' fields
+	*/
+	boardInterface := NewBoard(tilesets.StandardTileSet())
+	board := boardInterface.(*board)
+
+	tiles := []elements.PlacedTile{
+		elements.ToPlacedTile(tiletemplates.MonasteryWithSingleRoad().Rotate(1)),
+		elements.ToPlacedTile(tiletemplates.MonasteryWithSingleRoad().Rotate(1)),
+	}
+
+	// add meeple to the fields
+	tiles[0].GetPlacedFeatureAtSide(side.All, feature.Field).Meeple =
+		elements.Meeple{PlayerID: 1, Type: elements.NormalMeeple}
+	tiles[1].GetPlacedFeatureAtSide(side.All, feature.Field).Meeple =
+		elements.Meeple{PlayerID: 1, Type: elements.NormalMeeple}
+
+	// set positions
+	tiles[0].Position = position.New(0, -1)
+	tiles[1].Position = position.New(0, -2)
+
+	_, err := board.PlaceTile(tiles[0])
+	if err != nil {
+		t.Fatalf("error placing first tile: %#v", err)
+	}
+
+	_, err = board.PlaceTile(tiles[1])
+	if err == nil {
+		t.Fatalf("expected error placing second tile")
+	}
+}
+
+func TestConnectTwoFieldsWithMeeplesWithAThirdMeeple(t *testing.T) {
+	/*
+		the board setup is as follows:
+		─SM
+		M
+
+		S - starting tile
+		─ - road
+		M - monastery with a single road, going left
+
+		The tiles are placed in the following order:
+		(S), ─, M(bottom-left), M(right)
+
+		The meeples are placed on the top field of the ─ tile and on both monasteries' fields
+	*/
+	boardInterface := NewBoard(tilesets.StandardTileSet())
+	board := boardInterface.(*board)
+
+	tiles := []elements.PlacedTile{
+		elements.ToPlacedTile(tiletemplates.StraightRoads()),
+		elements.ToPlacedTile(tiletemplates.MonasteryWithSingleRoad().Rotate(1)),
+		elements.ToPlacedTile(tiletemplates.MonasteryWithSingleRoad().Rotate(1)),
+	}
+
+	// add meeple to the fields
+	tiles[0].GetPlacedFeatureAtSide(side.Top, feature.Field).Meeple =
+		elements.Meeple{PlayerID: 1, Type: elements.NormalMeeple}
+	tiles[1].GetPlacedFeatureAtSide(side.All, feature.Field).Meeple =
+		elements.Meeple{PlayerID: 1, Type: elements.NormalMeeple}
+	tiles[2].GetPlacedFeatureAtSide(side.All, feature.Field).Meeple =
+		elements.Meeple{PlayerID: 1, Type: elements.NormalMeeple}
+
+	// set positions
+	tiles[0].Position = position.New(-1, 0)
+	tiles[1].Position = position.New(-1, -1)
+	tiles[2].Position = position.New(1, 0)
+
+	_, err := board.PlaceTile(tiles[0])
+	if err != nil {
+		t.Fatalf("error placing first tile: %#v", err)
+	}
+
+	_, err = board.PlaceTile(tiles[1])
+	if err != nil {
+		t.Fatalf("error placing second tile: %#v", err)
+	}
+
+	_, err = board.PlaceTile(tiles[2])
+	if err == nil {
+		t.Fatalf("expected error placing third tile")
+	}
+}

--- a/pkg/game/city/city_manager.go
+++ b/pkg/game/city/city_manager.go
@@ -111,9 +111,9 @@ func (manager Manager) findCitiesToJoin(foundCities map[side.Side]int, tile elem
 }
 
 // Checks whether the tile can be placed at given position taking into account
-// the meeples placed on the given tile and the meeples that are already placed on
-// any city that the tile's features would join.
-func (manager *Manager) CanBePlaced(tile elements.PlacedTile) bool {
+// the meeple placed on the given feature and the meeples that are already placed on
+// any city that the feature would join.
+func (manager *Manager) CanBePlaced(tile elements.PlacedTile, feat elements.PlacedFeature) bool {
 	foundCities := manager.findCities(tile.Position)
 
 	if len(foundCities) == 0 {
@@ -122,23 +122,17 @@ func (manager *Manager) CanBePlaced(tile elements.PlacedTile) bool {
 		return true
 	}
 	citiesToJoin := manager.findCitiesToJoin(foundCities, tile)
-	for _, feature := range tile.Features {
-		if feature.Meeple.Type == elements.NoneMeeple {
-			// no meeple
-			continue
-		}
-		// this may return an empty list for features that have no cities to join with
-		cToJoin := citiesToJoin[feature]
+	// this may return an empty list for features that have no cities to join with
+	cToJoin := citiesToJoin[feat]
 
-		// Check each of the existing cities (if any) found in feature's neighbourhood
-		// We need to check, if they have *any* meeple placed
-		for _, cityIndex := range cToJoin {
-			// score report function checks the whole city for placed meeples
-			// and reports any meeples that would be returned which we can use here
-			scoreReport := manager.cities[cityIndex].GetScoreReport()
-			if len(scoreReport.ReturnedMeeples) != 0 {
-				return false
-			}
+	// Check each of the existing cities (if any) found in feature's neighbourhood
+	// We need to check, if they have *any* meeple placed
+	for _, cityIndex := range cToJoin {
+		// score report function checks the whole city for placed meeples
+		// and reports any meeples that would be returned which we can use here
+		scoreReport := manager.cities[cityIndex].GetScoreReport()
+		if len(scoreReport.ReturnedMeeples) != 0 {
+			return false
 		}
 	}
 

--- a/pkg/game/city/city_manager.go
+++ b/pkg/game/city/city_manager.go
@@ -127,14 +127,11 @@ func (manager *Manager) CanBePlaced(tile elements.PlacedTile) bool {
 			// no meeple
 			continue
 		}
-		cToJoin, exists := citiesToJoin[feature]
-		if !exists {
-			// no existing cities found in feature's neighbourhood - the feature is either
-			// not a City feature or it is a completely new city
-			continue
-		}
-		// existing city/cities found in feature's neighbourhood - we need to check,
-		// if they have *any* meeple placed
+		// this may return an empty list for features that have no cities to join with
+		cToJoin := citiesToJoin[feature]
+
+		// Check each of the existing cities (if any) found in feature's neighbourhood
+		// We need to check, if they have *any* meeple placed
 		for _, cityIndex := range cToJoin {
 			// score report function checks the whole city for placed meeples
 			// and reports any meeples that would be returned which we can use here

--- a/pkg/game/city/city_manager_test.go
+++ b/pkg/game/city/city_manager_test.go
@@ -532,6 +532,26 @@ func TestCanBePlacedReturnsTrueWhenOpeningNewCity(t *testing.T) {
 	}
 }
 
+func TestCanBePlacedReturnsTrueWhenClosingExistingCityAndOpeningNewCityWithMeeple(t *testing.T) {
+	manager := NewCityManager()
+
+	startingTile := elements.NewStartingTile(tilesets.StandardTileSet())
+	manager.UpdateCities(startingTile)
+
+	ptile := elements.ToPlacedTile(tiletemplates.TwoCityEdgesUpAndDownNotConnected())
+	ptile.Position = position.New(0, 1)
+	ptile.GetPlacedFeatureAtSide(side.Top, feature.City).Meeple = elements.Meeple{
+		Type: elements.NormalMeeple, PlayerID: 1,
+	}
+
+	expected := true
+	actual := manager.CanBePlaced(ptile)
+
+	if expected != actual {
+		t.Fatalf("expected %v, got %v instead", expected, actual)
+	}
+}
+
 func TestCanBePlacedReturnsTrueWhenClosingExistingCityAndPlacingFirstMeeple(t *testing.T) {
 	manager := NewCityManager()
 

--- a/pkg/game/city/city_manager_test.go
+++ b/pkg/game/city/city_manager_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/feature"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/side"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/tiletemplates"
+	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tilesets"
 )
 
 func TestDeepClone(t *testing.T) {
@@ -511,5 +512,108 @@ func TestGetCity(t *testing.T) {
 	}
 	if nilCityID != -1 {
 		t.Fatalf("expected %#v, got %#v instead", -1, nilCityID)
+	}
+}
+
+func TestCanBePlacedReturnsTrueWhenOpeningNewCity(t *testing.T) {
+	manager := NewCityManager()
+
+	startingTile := elements.NewStartingTile(tilesets.StandardTileSet())
+	manager.UpdateCities(startingTile)
+
+	ptile := elements.ToPlacedTile(tiletemplates.SingleCityEdgeNoRoads().Rotate(2))
+	ptile.Position = position.New(0, -1)
+
+	expected := true
+	actual := manager.CanBePlaced(ptile)
+
+	if expected != actual {
+		t.Fatalf("expected %v, got %v instead", expected, actual)
+	}
+}
+
+func TestCanBePlacedReturnsTrueWhenClosingExistingCityAndPlacingFirstMeeple(t *testing.T) {
+	manager := NewCityManager()
+
+	startingTile := elements.NewStartingTile(tilesets.StandardTileSet())
+	manager.UpdateCities(startingTile)
+
+	ptile := elements.ToPlacedTile(tiletemplates.SingleCityEdgeNoRoads().Rotate(2))
+	ptile.Position = position.New(0, 1)
+	ptile.GetPlacedFeatureAtSide(side.Bottom, feature.City).Meeple = elements.Meeple{
+		Type: elements.NormalMeeple, PlayerID: 1,
+	}
+
+	expected := true
+	actual := manager.CanBePlaced(ptile)
+
+	if expected != actual {
+		t.Fatalf("expected %v, got %v instead", expected, actual)
+	}
+}
+
+func TestCanBePlacedReturnsFalseWhenClosingExistingCityAndTryingToPlaceSecondMeeple(t *testing.T) {
+	manager := NewCityManager()
+
+	a := elements.ToPlacedTile(tiletemplates.SingleCityEdgeNoRoads())
+	a.GetPlacedFeatureAtSide(side.Top, feature.City).Meeple = elements.Meeple{
+		Type: elements.NormalMeeple, PlayerID: 1,
+	}
+	manager.UpdateCities(a)
+
+	b := elements.ToPlacedTile(tiletemplates.SingleCityEdgeNoRoads().Rotate(2))
+	b.Position = position.New(0, 1)
+	b.GetPlacedFeatureAtSide(side.Bottom, feature.City).Meeple = elements.Meeple{
+		Type: elements.NormalMeeple, PlayerID: 2,
+	}
+
+	expected := false
+	actual := manager.CanBePlaced(b)
+
+	if expected != actual {
+		t.Fatalf("expected %v, got %v instead", expected, actual)
+	}
+}
+
+func TestCanBePlacedReturnsTrueWhenExpandingExistingCityAndPlacingFirstMeeple(t *testing.T) {
+	manager := NewCityManager()
+
+	startingTile := elements.NewStartingTile(tilesets.StandardTileSet())
+	manager.UpdateCities(startingTile)
+
+	b := elements.ToPlacedTile(tiletemplates.TwoCityEdgesUpAndDownConnected())
+	b.Position = position.New(0, 1)
+	b.GetPlacedFeatureAtSide(side.Bottom, feature.City).Meeple = elements.Meeple{
+		Type: elements.NormalMeeple, PlayerID: 2,
+	}
+
+	expected := true
+	actual := manager.CanBePlaced(b)
+
+	if expected != actual {
+		t.Fatalf("expected %v, got %v instead", expected, actual)
+	}
+}
+
+func TestCanBePlacedReturnsFalseWhenExpandingExistingCityAndTryingToPlaceSecondMeeple(t *testing.T) {
+	manager := NewCityManager()
+
+	a := elements.ToPlacedTile(tiletemplates.SingleCityEdgeNoRoads())
+	a.GetPlacedFeatureAtSide(side.Top, feature.City).Meeple = elements.Meeple{
+		Type: elements.NormalMeeple, PlayerID: 1,
+	}
+	manager.UpdateCities(a)
+
+	b := elements.ToPlacedTile(tiletemplates.TwoCityEdgesUpAndDownConnected())
+	b.Position = position.New(0, 1)
+	b.GetPlacedFeatureAtSide(side.Bottom, feature.City).Meeple = elements.Meeple{
+		Type: elements.NormalMeeple, PlayerID: 2,
+	}
+
+	expected := false
+	actual := manager.CanBePlaced(b)
+
+	if expected != actual {
+		t.Fatalf("expected %v, got %v instead", expected, actual)
 	}
 }

--- a/pkg/game/city/city_manager_test.go
+++ b/pkg/game/city/city_manager_test.go
@@ -525,7 +525,7 @@ func TestCanBePlacedReturnsTrueWhenOpeningNewCity(t *testing.T) {
 	ptile.Position = position.New(0, -1)
 
 	expected := true
-	actual := manager.CanBePlaced(ptile)
+	actual := manager.CanBePlaced(ptile, *ptile.GetPlacedFeatureAtSide(side.Bottom, feature.City))
 
 	if expected != actual {
 		t.Fatalf("expected %v, got %v instead", expected, actual)
@@ -540,12 +540,11 @@ func TestCanBePlacedReturnsTrueWhenClosingExistingCityAndOpeningNewCityWithMeepl
 
 	ptile := elements.ToPlacedTile(tiletemplates.TwoCityEdgesUpAndDownNotConnected())
 	ptile.Position = position.New(0, 1)
-	ptile.GetPlacedFeatureAtSide(side.Top, feature.City).Meeple = elements.Meeple{
-		Type: elements.NormalMeeple, PlayerID: 1,
-	}
+	feat := ptile.GetPlacedFeatureAtSide(side.Top, feature.City)
+	feat.Meeple = elements.Meeple{Type: elements.NormalMeeple, PlayerID: 1}
 
 	expected := true
-	actual := manager.CanBePlaced(ptile)
+	actual := manager.CanBePlaced(ptile, *feat)
 
 	if expected != actual {
 		t.Fatalf("expected %v, got %v instead", expected, actual)
@@ -560,12 +559,11 @@ func TestCanBePlacedReturnsTrueWhenClosingExistingCityAndPlacingFirstMeeple(t *t
 
 	ptile := elements.ToPlacedTile(tiletemplates.SingleCityEdgeNoRoads().Rotate(2))
 	ptile.Position = position.New(0, 1)
-	ptile.GetPlacedFeatureAtSide(side.Bottom, feature.City).Meeple = elements.Meeple{
-		Type: elements.NormalMeeple, PlayerID: 1,
-	}
+	feat := ptile.GetPlacedFeatureAtSide(side.Bottom, feature.City)
+	feat.Meeple = elements.Meeple{Type: elements.NormalMeeple, PlayerID: 1}
 
 	expected := true
-	actual := manager.CanBePlaced(ptile)
+	actual := manager.CanBePlaced(ptile, *feat)
 
 	if expected != actual {
 		t.Fatalf("expected %v, got %v instead", expected, actual)
@@ -583,12 +581,11 @@ func TestCanBePlacedReturnsFalseWhenClosingExistingCityAndTryingToPlaceSecondMee
 
 	b := elements.ToPlacedTile(tiletemplates.SingleCityEdgeNoRoads().Rotate(2))
 	b.Position = position.New(0, 1)
-	b.GetPlacedFeatureAtSide(side.Bottom, feature.City).Meeple = elements.Meeple{
-		Type: elements.NormalMeeple, PlayerID: 2,
-	}
+	feat := b.GetPlacedFeatureAtSide(side.Bottom, feature.City)
+	feat.Meeple = elements.Meeple{Type: elements.NormalMeeple, PlayerID: 2}
 
 	expected := false
-	actual := manager.CanBePlaced(b)
+	actual := manager.CanBePlaced(b, *feat)
 
 	if expected != actual {
 		t.Fatalf("expected %v, got %v instead", expected, actual)
@@ -603,12 +600,11 @@ func TestCanBePlacedReturnsTrueWhenExpandingExistingCityAndPlacingFirstMeeple(t 
 
 	b := elements.ToPlacedTile(tiletemplates.TwoCityEdgesUpAndDownConnected())
 	b.Position = position.New(0, 1)
-	b.GetPlacedFeatureAtSide(side.Bottom, feature.City).Meeple = elements.Meeple{
-		Type: elements.NormalMeeple, PlayerID: 2,
-	}
+	feat := b.GetPlacedFeatureAtSide(side.Bottom, feature.City)
+	feat.Meeple = elements.Meeple{Type: elements.NormalMeeple, PlayerID: 2}
 
 	expected := true
-	actual := manager.CanBePlaced(b)
+	actual := manager.CanBePlaced(b, *feat)
 
 	if expected != actual {
 		t.Fatalf("expected %v, got %v instead", expected, actual)
@@ -626,12 +622,11 @@ func TestCanBePlacedReturnsFalseWhenExpandingExistingCityAndTryingToPlaceSecondM
 
 	b := elements.ToPlacedTile(tiletemplates.TwoCityEdgesUpAndDownConnected())
 	b.Position = position.New(0, 1)
-	b.GetPlacedFeatureAtSide(side.Bottom, feature.City).Meeple = elements.Meeple{
-		Type: elements.NormalMeeple, PlayerID: 2,
-	}
+	feat := b.GetPlacedFeatureAtSide(side.Bottom, feature.City)
+	feat.Meeple = elements.Meeple{Type: elements.NormalMeeple, PlayerID: 2}
 
 	expected := false
-	actual := manager.CanBePlaced(b)
+	actual := manager.CanBePlaced(b, *feat)
 
 	if expected != actual {
 		t.Fatalf("expected %v, got %v instead", expected, actual)

--- a/pkg/game/elements/placed_tile.go
+++ b/pkg/game/elements/placed_tile.go
@@ -92,8 +92,13 @@ func (placedTile *PlacedTile) GetPlacedFeatureAtSide(sideToCheck side.Side, feat
 	return nil
 }
 
-func NewStartingTile(tileSet tilesets.TileSet) PlacedTile {
-	return ToPlacedTile(tileSet.StartingTile)
+func (placedTile PlacedTile) HasMeeple() bool {
+	for _, feat := range placedTile.Features {
+		if feat.Meeple.Type != NoneMeeple {
+			return true
+		}
+	}
+	return false
 }
 
 func (placedTile PlacedTile) Monastery() *PlacedFeature {
@@ -103,4 +108,8 @@ func (placedTile PlacedTile) Monastery() *PlacedFeature {
 		}
 	}
 	return nil
+}
+
+func NewStartingTile(tileSet tilesets.TileSet) PlacedTile {
+	return ToPlacedTile(tileSet.StartingTile)
 }

--- a/pkg/game/game.go
+++ b/pkg/game/game.go
@@ -133,7 +133,26 @@ func (game *Game) GetTilePlacementsFor(tile tiles.Tile) []elements.PlacedTile {
 }
 
 func (game *Game) GetLegalMovesFor(placement elements.PlacedTile) []elements.PlacedTile {
-	return game.board.GetLegalMovesFor(placement)
+	moves := []elements.PlacedTile{}
+	player := game.CurrentPlayer()
+
+outer:
+	for _, move := range game.board.GetLegalMovesFor(placement) {
+		for i, feat := range move.Features {
+			if feat.Meeple.Type != elements.NoneMeeple {
+				if player.MeepleCount(feat.Meeple.Type) == 0 {
+					// filter out moves that the current player cannot perform
+					continue outer
+				}
+				feat.Meeple.PlayerID = game.CurrentPlayer().ID()
+				move.Features[i] = feat
+			}
+		}
+
+		moves = append(moves, move)
+	}
+
+	return moves
 }
 
 func (game *Game) ensureCurrentTileHasValidPlacement() error {

--- a/pkg/game/game_test.go
+++ b/pkg/game/game_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/deck"
@@ -237,6 +238,7 @@ func TestGameGetLegalMovesForIncludesMeepleTypesCurrentPlayerDoesHave(t *testing
 	expected := []elements.PlacedTile{basePlacement}
 	for i := range basePlacement.Features {
 		ptile := basePlacement
+		ptile.Features = slices.Clone(basePlacement.Features)
 		ptile.Features[i].Meeple = elements.Meeple{
 			Type: elements.NormalMeeple, PlayerID: 1,
 		}

--- a/pkg/game/game_test.go
+++ b/pkg/game/game_test.go
@@ -115,7 +115,7 @@ func TestDeepClone(t *testing.T) {
 func TestFullGame(t *testing.T) {
 	tileSet := tilesets.StandardTileSet()
 	tileSet.Tiles = []tiles.Tile{
-		tiletemplates.SingleCityEdgeNoRoads(),
+		tiletemplates.SingleCityEdgeNoRoads().Rotate(2),
 		tiletemplates.StraightRoads(),
 	}
 	deckStack := stack.NewOrdered(tileSet.Tiles)
@@ -131,7 +131,7 @@ func TestFullGame(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	ptile := elements.ToPlacedTile(tile)
-	ptile.Position = position.New(0, -1)
+	ptile.Position = position.New(0, 1)
 	err = game.PlayTurn(ptile)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -140,7 +140,7 @@ func TestFullGame(t *testing.T) {
 	// incorrect move - try placing tile 0 when 1 should be placed
 	tile = tileSet.Tiles[0]
 	ptile = elements.ToPlacedTile(tile)
-	ptile.Position = position.New(0, 1)
+	ptile.Position = position.New(0, -1)
 	err = game.PlayTurn(ptile)
 	if err == nil {
 		t.Fatal("expected error to occur")
@@ -155,7 +155,7 @@ func TestFullGame(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	ptile = elements.ToPlacedTile(tile)
-	ptile.Position = position.New(0, 1)
+	ptile.Position = position.New(0, -1)
 	err = game.PlayTurn(ptile)
 	if err != nil {
 		t.Fatal(err.Error())

--- a/pkg/player/player.go
+++ b/pkg/player/player.go
@@ -64,6 +64,9 @@ func (player *player) IsEligibleFor(move elements.PlacedTile) bool {
 	count := 0
 	for _, feature := range move.Features {
 		if feature.Meeple.Type != elements.NoneMeeple {
+			if feature.Meeple.PlayerID != player.id {
+				return false
+			}
 			if player.MeepleCount(feature.Meeple.Type) == 0 {
 				return false
 			}


### PR DESCRIPTION
Fixes #29
and updates all things (`GetLegalMovesFor`, `PlaceTile`) that should be using this functionality but couldn't because it didn't exist then.
