### PR TITLE
Fix 2nd field's Sides in TwoCityEdgesUpAndDownConnected() template

### DIFF
--- a/pkg/tiles/tiletemplates/tile_templates.go
+++ b/pkg/tiles/tiletemplates/tile_templates.go
@@ -429,8 +429,8 @@ func TwoCityEdgesUpAndDownConnected() tiles.Tile {
 			},
 			{
 				FeatureType: feature.Field,
-				Sides: side.BottomLeftEdge |
-					side.BottomRightEdge,
+				Sides: side.RightTopEdge |
+					side.RightBottomEdge,
 			},
 		},
 	}


### PR DESCRIPTION
This is the tile that was meant to be represented by this template:
![image](https://github.com/user-attachments/assets/e48dedfc-3281-4a52-b4a0-0c88cf17e84e)
