### PR TITLE
Recover from panics in GameEngine requests

### DIFF
--- a/pkg/engine/base_structures.go
+++ b/pkg/engine/base_structures.go
@@ -77,3 +77,12 @@ func (resp *BaseResponse) Err() error {
 type SyncResponse struct {
 	BaseResponse
 }
+
+func (resp *SyncResponse) canRemoveGame() bool {
+	err := resp.Err()
+	if err == nil {
+		return false
+	}
+	_, panicOccured := err.(*ExecutionPanicError)
+	return panicOccured
+}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -33,7 +33,7 @@ type ExecutionPanicError struct {
 
 func (err *ExecutionPanicError) Error() string {
 	return fmt.Sprintf(
-		"panic occurred during request execution\n- msg: %#v\n- stack trace:\n%s",
+		"panic during request execution: %#v\n- stack trace:\n%s",
 		err.panicValue,
 		err.stack,
 	)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -343,7 +343,7 @@ func (engine *GameEngine) SendGetLegalMovesBatch(concreteRequests []*GetLegalMov
 // API for handling the sent requests using background workers.
 // The order and types of returned responses correspond to the requests slice.
 //
-// If a request fails before reaching a worker, a `SyncResponse` type will be
+// If a request fails before reaching a worker, a `SyncResponse` type will
 // be returned in place of the worker response.
 // If a panic occurs during execution of this method, it will be captured
 // and a SyncResponse with ExecutionPanicError will be returned for relevant

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -467,10 +467,6 @@ func (engine *GameEngine) sendBatch(requests []Request) []Response {
 	close(outputBuffer)
 	outputWaitGroup.Wait()
 
-	if outputPanicValue != nil {
-		panic(outputPanicValue)
-	}
-
 	return responses
 }
 

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -640,6 +640,13 @@ func TestGameEngineSendBatchReturnsExecutionPanicErrorOnPanicEverywhere(t *testi
 		if !panicOccured {
 			t.Fatal(err)
 		}
+		msg := err.Error()
+		if strings.Count(msg, "stack trace") < 2 {
+			t.Fatalf(
+				"expected at least 2 stack traces, got following message instead:\n%v",
+				msg,
+			)
+		}
 		expected := requests[i].gameID()
 		actual := resp.GameID()
 		if actual != expected {


### PR DESCRIPTION
Fixes #82 

Comes with a refactor of `sendBatch` to a new class as the original implementation which became rather lengthy and not particularly easy to read.

Diff from before the refactor:
https://github.com/YetAnotherSpieskowcy/Carcassonne-Engine/compare/f07e719526a5b63ebe84f1c1f0132a58f59ed736

