### PR TITLE
Ensure input to Game.PlayTurn is fully copied

### DIFF
--- a/pkg/game/board.go
+++ b/pkg/game/board.go
@@ -141,8 +141,7 @@ func (board *board) GetLegalMovesFor(basePlacement elements.PlacedTile) []elemen
 
 	for i := range basePlacement.Features {
 		for _, meepleType := range meepleTypes {
-			placement := basePlacement
-			placement.Features = slices.Clone(basePlacement.Features)
+			placement := basePlacement.DeepClone()
 			placement.Features[i].Meeple = elements.Meeple{Type: meepleType}
 			feat := placement.Features[i]
 

--- a/pkg/game/board_test.go
+++ b/pkg/game/board_test.go
@@ -126,8 +126,7 @@ func TestBoardGetLegalMovesForDoesNotIncludeInvalidMeeplePlacements(t *testing.T
 		tiletemplates.SingleCityEdgeNoRoads().Rotate(2),
 	)
 	basePlacement.Position = position.New(0, 2)
-	placementWithMeeple := basePlacement
-	placementWithMeeple.Features = slices.Clone(basePlacement.Features)
+	placementWithMeeple := basePlacement.DeepClone()
 	placementWithMeeple.GetPlacedFeatureAtSide(
 		side.Top, feature.Field,
 	).Meeple = elements.Meeple{Type: elements.NormalMeeple}

--- a/pkg/game/elements/placed_tile.go
+++ b/pkg/game/elements/placed_tile.go
@@ -1,6 +1,8 @@
 package elements
 
 import (
+	"slices"
+
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/game/position"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/feature"
@@ -32,6 +34,11 @@ type PlacedFeature struct {
 type PlacedTile struct {
 	Features []PlacedFeature
 	Position position.Position
+}
+
+func (placedTile PlacedTile) DeepClone() PlacedTile {
+	placedTile.Features = slices.Clone(placedTile.Features)
+	return placedTile
 }
 
 func (placedTile PlacedTile) Rotate(rotations uint) PlacedTile {

--- a/pkg/game/game.go
+++ b/pkg/game/game.go
@@ -223,6 +223,8 @@ func (game *Game) PlayTurn(move elements.PlacedTile) error {
 		return fmt.Errorf("%w: %#v", elements.ErrWrongTile, currentTile)
 	}
 	player := game.CurrentPlayer()
+	// prevent reusing underlying Features slice
+	move = move.DeepClone()
 
 	// In the class diagram, the `scoreReport` would be returned by
 	// separate `CheckCompleted()` method but it's been abstracted by PlaceTile instead.

--- a/pkg/game/game_test.go
+++ b/pkg/game/game_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"io"
 	"reflect"
-	"slices"
 	"testing"
 
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/deck"
@@ -259,8 +258,7 @@ func TestGameGetLegalMovesForIncludesMeepleTypesCurrentPlayerDoesHave(t *testing
 	basePlacement := game.GetTilePlacementsFor(tile)[0]
 	expected := []elements.PlacedTile{basePlacement}
 	for i := range basePlacement.Features {
-		ptile := basePlacement
-		ptile.Features = slices.Clone(basePlacement.Features)
+		ptile := basePlacement.DeepClone()
 		ptile.Features[i].Meeple = elements.Meeple{
 			Type: elements.NormalMeeple, PlayerID: 1,
 		}

--- a/pkg/game/game_test.go
+++ b/pkg/game/game_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/logger"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/stack"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles"
+	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/feature"
+	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/side"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tiles/tiletemplates"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tilesets"
 )
@@ -355,5 +357,33 @@ func TestGameSwapCurrentTileSwapTileOnCloneWithSwappableTiles(t *testing.T) {
 
 	if !tile.ExactEquals(tileSet.Tiles[1]) {
 		t.Fatalf("expected %#v, got %#v instead", tileSet.Tiles[1], tile)
+	}
+}
+
+func TestGamePlayTurnDoesNotMutateInput(t *testing.T) {
+	tileSet := tilesets.StandardTileSet()
+	tileSet.Tiles = []tiles.Tile{tiletemplates.SingleCityEdgeNoRoads().Rotate(2)}
+
+	game, err := NewFromTileSet(tileSet, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := elements.Meeple{
+		Type:     elements.NormalMeeple,
+		PlayerID: game.CurrentPlayer().ID(),
+	}
+	ptile := elements.ToPlacedTile(tileSet.Tiles[0])
+	ptile.Position = position.New(0, 1)
+	ptile.GetPlacedFeatureAtSide(side.Bottom, feature.City).Meeple = expected
+
+	err = game.PlayTurn(ptile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual := ptile.GetPlacedFeatureAtSide(side.Bottom, feature.City).Meeple
+	if expected != actual {
+		t.Fatalf("expected %#v, got %#v instead", expected, actual)
 	}
 }


### PR DESCRIPTION
Fixes #105 

The problem in the issue is triggered by `GetLegalMovesFor.execute()` passing `PlacedTile` to `Game.PlayTurn()`, expecting it to not be mutated. This is not actually the case though as the underlying slice is never copied. This PR fixes that. Since the pattern of copying `Features` can be seen in a few places in the codebase already, I went ahead and replaced them with the new `PlacedTile.DeepClone()` method call.