### PR TITLE
Make SerializedGameWithID constructor part of the API contract

### DIFF
--- a/python_bindings/carcassonne_engine/models.py
+++ b/python_bindings/carcassonne_engine/models.py
@@ -9,7 +9,14 @@ from ._bindings import (  # type: ignore[attr-defined] # no stubs
     tiles as _go_tiles,
 )
 
-__all__ = ("GameState", "PlacedTile", "SerializedGame", "Tile")
+__all__ = (
+    "GameState",
+    "Tile",
+    "SerializedGame",
+    "SerializedGameWithID",
+    "Position",
+    "PlacedTile",
+)
 
 
 class GameState:
@@ -96,9 +103,6 @@ class SerializedGame:
 class SerializedGameWithID(NamedTuple):
     """
     A serialized game consisting of its ID and serialized state.
-
-    This class is not meant to be instantiated by users directly
-    and should be considered read-only.
 
     The instances of this class are provided by the `GameEngine` objects.
     """


### PR DESCRIPTION
@bstrzelecki wanted this to be added to the API contract and since it's a simple attribute container, why not? I updated `__all__` to include it and `Position` which was also missing.

This will almost certainly conflict with #93 and this is not terribly important so I suggest waiting until that's merged.