### PR TITLE
Add GameEngine.generate_ordered_game() for testing purposes

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -10,8 +10,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/deck"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/game"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/logger"
+	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/stack"
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/tilesets"
 )
 
@@ -158,6 +160,22 @@ func (engine *GameEngine) Close() {
 
 // Generate a random game from the given tileset.
 func (engine *GameEngine) GenerateGame(tileSet tilesets.TileSet) (SerializedGameWithID, error) {
+	deckStack := stack.New(tileSet.Tiles)
+	deck := deck.Deck{Stack: &deckStack, StartingTile: tileSet.StartingTile}
+	return engine.generateGameFromDeck(deck)
+}
+
+// Generate a game from the given tileset using its defined tile order.
+//
+// Usage for games played by an agent is ill-advised - the serialized game reveals
+// the tileset and the order in it will be consistent with stack's order.
+func (engine *GameEngine) GenerateOrderedGame(tileSet tilesets.TileSet) (SerializedGameWithID, error) {
+	deckStack := stack.NewOrdered(tileSet.Tiles)
+	deck := deck.Deck{Stack: &deckStack, StartingTile: tileSet.StartingTile}
+	return engine.generateGameFromDeck(deck)
+}
+
+func (engine *GameEngine) generateGameFromDeck(deck deck.Deck) (SerializedGameWithID, error) {
 	id := engine.nextGameID
 	engine.nextGameID++
 
@@ -167,7 +185,7 @@ func (engine *GameEngine) GenerateGame(tileSet tilesets.TileSet) (SerializedGame
 		return SerializedGameWithID{}, err
 	}
 
-	g, err := game.NewFromTileSet(tileSet, &logger)
+	g, err := game.NewFromDeck(deck, &logger)
 	if err != nil {
 		return SerializedGameWithID{}, err
 	}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -59,14 +59,23 @@ func TestFullGame(t *testing.T) {
 	}
 	tileSet := tilesets.StandardTileSet()
 
-	gameWithID, err := engine.GenerateGame(tileSet)
+	gameWithID, err := engine.GenerateOrderedGame(tileSet)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 	game, gameID := gameWithID.Game, gameWithID.ID
 
 	t.Logf("before loop: %s\n", time.Now())
-	for i := range len(tileSet.Tiles) {
+	for i, expectedTile := range tileSet.Tiles {
+		if !game.CurrentTile.Equals(expectedTile) {
+			t.Fatalf(
+				"expected %v-th tile to be %#v, got %#v instead",
+				i,
+				expectedTile,
+				game.CurrentTile,
+			)
+		}
+
 		t.Logf(
 			"iteration %v start: %v\n", i, binarytiles.FromTile(game.CurrentTile),
 		)
@@ -98,13 +107,6 @@ func TestFullGame(t *testing.T) {
 		game = playTurnResp.Game
 		gameID = playTurnResp.GameID()
 		t.Logf("iteration %v end: %s\n", i, time.Now())
-
-		if len(game.CurrentTile.Features) == 0 {
-			// number of tiles in the tile set and number of tiles that you actually
-			// get to place can differ, if a tile that's next in the stack happens to
-			// not have any position to place available
-			break
-		}
 	}
 
 	if len(game.CurrentTile.Features) != 0 {

--- a/python_bindings/carcassonne_engine/tilesets.py
+++ b/python_bindings/carcassonne_engine/tilesets.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from typing import Self
 
 from ._bindings import (  # type: ignore[attr-defined] # no stubs
@@ -29,6 +30,10 @@ class TileSet:
 
     def __len__(self) -> int:
         return len(self._go_obj.Tiles) + 1
+
+    def __iter__(self) -> Iterator[Tile]:
+        for go_tile in self._go_obj.Tiles:
+            yield Tile(go_tile)
 
     @classmethod
     def from_tiles(cls, tiles: list[Tile], *, starting_tile: Tile) -> Self:

--- a/python_bindings/tests/engine_test.py
+++ b/python_bindings/tests/engine_test.py
@@ -20,10 +20,10 @@ def test_full_game(tmp_path: Path) -> None:
     engine = GameEngine(4, tmp_path)
     tile_set = standard_tile_set()
 
-    game_id, game = engine.generate_game(tile_set)
+    game_id, game = engine.generate_ordered_game(tile_set)
 
-    for i in range(len(tile_set) - 1):
-        assert game.current_tile is not None
+    for i, expected_tile in enumerate(tile_set):
+        assert game.current_tile == expected_tile
         log.info(
             "iteration %s start: %s",
             i,
@@ -53,12 +53,6 @@ def test_full_game(tmp_path: Path) -> None:
         game = play_turn_resp.game
         game_id = play_turn_resp.game_id
         log.info("iteration %s end", i)
-
-        if game.current_tile is None:
-            # number of tiles in the tile set and number of tiles that you actually
-            # get to place can differ, if a tile that's next in the stack happens to
-            # not have any position to place available
-            break
 
     assert game.current_tile is None
 


### PR DESCRIPTION
Based on #73 with some modifications:
- the implementations of `GenerateGame` and `GenerateOrderedGame` are now mostly shared
- to test `GenerateOrderedGame()`, the current non-deterministic `TestFullGame` test (and its Python counterpart) has been updated to use it and to test the expected tile order
    - this required adding a way to iterate over a `TileSet` on the Python side
- I documented why it is ill-advised to use this for non-testing purposes
    - I could fix it but I was hoping to avoid changing the implementation that @Kaszana102's PRs use unless it's determined that we actually need it

This unblocks the following conversations on #84:
- https://github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pull/84#discussion_r1765886696
- https://github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pull/84#discussion_r1765899179
