### PR TITLE
Add score events to log mid-game

### DIFF
--- a/pkg/game/elements/score_report.go
+++ b/pkg/game/elements/score_report.go
@@ -34,6 +34,10 @@ func NewScoreReport() ScoreReport {
 	}
 }
 
+func (report *ScoreReport) IsEmpty() bool {
+	return len(report.ReceivedPoints) == 0 && len(report.ReturnedMeeples) == 0
+}
+
 // Adds the contents of otherReport to the contents of this score report
 func (report *ScoreReport) Join(otherReport ScoreReport) {
 	for playerID, score := range otherReport.ReceivedPoints {

--- a/pkg/game/game.go
+++ b/pkg/game/game.go
@@ -299,7 +299,11 @@ func (game *Game) Finalize() (elements.ScoreReport, error) {
 	meeplesReport := game.board.ScoreMeeples(true)
 	playerScores.Join(meeplesReport)
 
-	if err := game.log.LogEvent(logger.ScoreEvent, logger.NewScoreEntryContent(playerScores)); err != nil {
+	if err := game.log.LogEvent(logger.ScoreEvent, logger.NewScoreEntryContent(meeplesReport)); err != nil {
+		return playerScores, err
+	}
+
+	if err := game.log.LogEvent(logger.FinalScoreEvent, logger.NewFinalScoreEntryContent(playerScores)); err != nil {
 		return playerScores, err
 	}
 

--- a/pkg/game/game.go
+++ b/pkg/game/game.go
@@ -262,6 +262,14 @@ func (game *Game) PlayTurn(move elements.PlacedTile) error {
 		}
 	}
 
+	if !scoreReport.IsEmpty() {
+		if err = game.log.LogEvent(
+			logger.ScoreEvent, logger.NewScoreEntryContent(scoreReport),
+		); err != nil {
+			return err
+		}
+	}
+
 	// Pop from the stack after the move.
 	if _, err = game.deck.Next(); err != nil {
 		return err

--- a/pkg/logger/log_entries.go
+++ b/pkg/logger/log_entries.go
@@ -10,9 +10,10 @@ import (
 type EventType string
 
 const (
-	StartEvent     EventType = "start"
-	PlaceTileEvent EventType = "place"
-	ScoreEvent     EventType = "score"
+	StartEvent      EventType = "start"
+	PlaceTileEvent  EventType = "place"
+	ScoreEvent      EventType = "score"
+	FinalScoreEvent EventType = "final_score"
 )
 
 type Entry struct {
@@ -81,6 +82,23 @@ func NewScoreEntryContent(scores elements.ScoreReport) ScoreEntryContent {
 
 func ParseScoreEntryContent(entryContent []byte) ScoreEntryContent {
 	var content ScoreEntryContent
+	err := json.Unmarshal(entryContent, &content)
+	if err != nil {
+		panic(err)
+	}
+	return content
+}
+
+type FinalScoreEntryContent struct {
+	Scores elements.ScoreReport `json:"scores"`
+}
+
+func NewFinalScoreEntryContent(scores elements.ScoreReport) FinalScoreEntryContent {
+	return FinalScoreEntryContent{Scores: scores}
+}
+
+func ParseFinalScoreEntryContent(entryContent []byte) FinalScoreEntryContent {
+	var content FinalScoreEntryContent
 	err := json.Unmarshal(entryContent, &content)
 	if err != nil {
 		panic(err)

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -374,6 +374,14 @@ func TestParseEntries(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
+	expectedFinalScores := elements.NewScoreReport()
+	expectedFinalScores.ReceivedPoints[playerID.ID()] = 6
+	expectedFinalScores.ReceivedPoints[elements.ID(2)] = 3
+	err = log.LogEvent(ScoreEvent, NewFinalScoreEntryContent(expectedFinalScores))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
 	line, err := buffer.ReadString(byte('\n'))
 	if err != nil {
 		t.Fatal(err.Error())
@@ -441,5 +449,24 @@ func TestParseEntries(t *testing.T) {
 	}
 	if !reflect.DeepEqual(scoreContent.Scores, expectedScores) {
 		t.Fatalf("expected %#v, got %#v instead", expectedScores, scoreContent.Scores)
+	}
+
+	line, err = buffer.ReadString(byte('\n'))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = json.Unmarshal([]byte(line), &entryLine)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if entryLine.Event != ScoreEvent {
+		t.Fatalf("expected %#v, got %#v instead", ScoreEvent, entryLine.Event)
+	}
+	finalScoreContent := ParseFinalScoreEntryContent(entryLine.Content)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if !reflect.DeepEqual(finalScoreContent.Scores, expectedFinalScores) {
+		t.Fatalf("expected %#v, got %#v instead", expectedFinalScores, finalScoreContent.Scores)
 	}
 }


### PR DESCRIPTION
This PR does 3 things:
- adds a score entry in each turn where scores change
- changes existing score entry in `Game.Finalize()` to log scores just from the finalization part
- adds a new event for final scores
    - this is expected to be equivalent to summing up values from all score events from the log

Because final scoring is a new event (which Visualiser's log parser will just ignore) and Visualiser already expects score events to only contain *new* points, this should require no change on the Visualiser's side.
This new event allows you to tell when the game is truly finished so it could be potentially useful for log-following functionality as well.

Fixes #114