### PR TITLE
Fix PlacedTile immutability assumption in board.DeepClone()

### DIFF
--- a/pkg/game/board.go
+++ b/pkg/game/board.go
@@ -306,6 +306,11 @@ func (board *board) roadCanBePlaced(checkedTile elements.PlacedTile, checkedRoad
 	return true
 }
 
+// Add a tile to the board and propagate feature completion
+// to other tiles on the board (including meeple removal).
+//
+// Anything not managed by the board, such as players, will need to be updated
+// by the caller.
 func (board *board) PlaceTile(tile elements.PlacedTile) (elements.ScoreReport, error) {
 	err := board.addTileToBoard(tile)
 	if err != nil {
@@ -314,6 +319,8 @@ func (board *board) PlaceTile(tile elements.PlacedTile) (elements.ScoreReport, e
 	return board.checkCompleted(tile), nil
 }
 
+// Add a tile to the board without propagating feature completion to
+// other tiles on the board or removing meeples.
 func (board *board) addTileToBoard(tile elements.PlacedTile) error {
 	if board.TileCount() == cap(board.tiles) {
 		return errors.New("Board's tiles capacity exceeded, logic error?")

--- a/pkg/game/board.go
+++ b/pkg/game/board.go
@@ -337,8 +337,8 @@ func (board *board) PlaceTile(tile elements.PlacedTile) (elements.ScoreReport, e
 	board.updateValidPlacements(tile)
 	board.tiles[actualIndex] = tile
 	board.tilesMap[tile.Position] = tile
-	scoreReport, err := board.checkCompleted(tile)
-	return scoreReport, err
+	scoreReport := board.checkCompleted(tile)
+	return scoreReport, nil
 }
 
 func (board *board) RemoveMeeple(pos position.Position) {
@@ -371,20 +371,20 @@ func (board *board) updateValidPlacements(tile elements.PlacedTile) {
 	}
 }
 
-func (board *board) checkCompleted(
-	//revive:disable-next-line:unused-parameter Until the TODO is finished.
-	tile elements.PlacedTile,
-) (elements.ScoreReport, error) {
-	// TODO for future tasks:
-	// - identify all completed features
-	// - resolve control of the completed features
-	// - award points
+func (board *board) checkCompleted(tile elements.PlacedTile) elements.ScoreReport {
 	scoreReport := elements.NewScoreReport()
 	board.cityManager.UpdateCities(tile)
 	scoreReport.Join(board.cityManager.ScoreCities(false))
 	scoreReport.Join(board.ScoreRoads(tile, false))
 	scoreReport.Join(board.ScoreMonasteries(tile, false))
-	return scoreReport, nil
+
+	for _, returnedMeeples := range scoreReport.ReturnedMeeples {
+		for _, meeple := range returnedMeeples {
+			board.RemoveMeeple(meeple.Position)
+		}
+	}
+
+	return scoreReport
 }
 
 /*

--- a/pkg/game/board.go
+++ b/pkg/game/board.go
@@ -83,10 +83,13 @@ func (board board) DeepClone() elements.Board {
 
 	tiles[0] = board.tiles[0]
 	for i, tile := range board.tiles {
-		if tile.Position.X() == 0 && tile.Position.Y() == 0 {
-			continue
+		// `board.tiles` is fixed size vector with space for all placed tiles
+		// but only some are actually real rather than zero values.
+		// Check one of the structure's fields for value that it could not possibly have
+		// i.e. nil slice of features
+		if tile.Features != nil {
+			tiles[i] = tilesMap[tile.Position]
 		}
-		tiles[i] = tilesMap[tile.Position]
 	}
 	board.tiles = tiles
 

--- a/pkg/game/board.go
+++ b/pkg/game/board.go
@@ -304,14 +304,20 @@ func (board *board) roadCanBePlaced(checkedTile elements.PlacedTile, checkedRoad
 }
 
 func (board *board) PlaceTile(tile elements.PlacedTile) (elements.ScoreReport, error) {
+	err := board.addTileToBoard(tile)
+	if err != nil {
+		return elements.ScoreReport{}, err
+	}
+	return board.checkCompleted(tile), nil
+}
+
+func (board *board) addTileToBoard(tile elements.PlacedTile) error {
 	if board.TileCount() == cap(board.tiles) {
-		return elements.ScoreReport{}, errors.New(
-			"Board's tiles capacity exceeded, logic error?",
-		)
+		return errors.New("Board's tiles capacity exceeded, logic error?")
 	}
 
 	if !board.CanBePlaced(tile) {
-		return elements.ScoreReport{}, elements.ErrInvalidPosition
+		return elements.ErrInvalidPosition
 	}
 
 	setTiles := board.tileSet.Tiles
@@ -321,9 +327,7 @@ func (board *board) PlaceTile(tile elements.PlacedTile) (elements.ScoreReport, e
 			return elements.ToTile(tile).Equals(candidate)
 		})
 		if index == -1 {
-			return elements.ScoreReport{}, errors.New(
-				"Placed tile not found in the tile set, logic error?",
-			)
+			return errors.New("Placed tile not found in the tile set, logic error?")
 		}
 		actualIndex += index
 		if !elements.ToTile(board.tiles[actualIndex]).Equals(elements.ToTile(tile)) {
@@ -337,8 +341,8 @@ func (board *board) PlaceTile(tile elements.PlacedTile) (elements.ScoreReport, e
 	board.updateValidPlacements(tile)
 	board.tiles[actualIndex] = tile
 	board.tilesMap[tile.Position] = tile
-	scoreReport := board.checkCompleted(tile)
-	return scoreReport, nil
+
+	return nil
 }
 
 func (board *board) RemoveMeeple(pos position.Position) {

--- a/pkg/game/board.go
+++ b/pkg/game/board.go
@@ -3,7 +3,6 @@ package game
 import (
 	"errors"
 	"fmt"
-	"maps"
 	"slices"
 
 	"github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pkg/game/city"
@@ -73,9 +72,23 @@ func NewBoard(tileSet tilesets.TileSet) elements.Board {
 func (board board) DeepClone() elements.Board {
 	// note: skipped board.tileSet because TileSet is immutable
 
-	// PlacedTile is not mutated after it's placed
-	board.tiles = slices.Clone(board.tiles)
-	board.tilesMap = maps.Clone(board.tilesMap)
+	tilesMap := map[position.Position]elements.PlacedTile{}
+	tiles := make([]elements.PlacedTile, len(board.tileSet.Tiles)+1)
+
+	for pos, tile := range board.tilesMap {
+		tile = tile.DeepClone()
+		tilesMap[pos] = tile
+	}
+	board.tilesMap = tilesMap
+
+	tiles[0] = board.tiles[0]
+	for i, tile := range board.tiles {
+		if tile.Position.X() == 0 && tile.Position.Y() == 0 {
+			continue
+		}
+		tiles[i] = tilesMap[tile.Position]
+	}
+	board.tiles = tiles
 
 	// Position is immutable
 	board.placeablePositions = slices.Clone(board.placeablePositions)

--- a/pkg/game/board_test.go
+++ b/pkg/game/board_test.go
@@ -411,7 +411,7 @@ func TestBoardScoreIncompleteMonastery(t *testing.T) {
 
 	// place tiles
 	for i, tile := range tiles {
-		_, err := board.PlaceTile(tile)
+		err := board.addTileToBoard(tile)
 		if err != nil {
 			t.Fatalf("error placing tile number: %#v: %#v", i, err)
 		}
@@ -509,7 +509,7 @@ func TestBoardCompleteTwoMonasteriesAtOnce(t *testing.T) {
 
 	// place tiles
 	for i, tile := range tiles[:len(tiles)-1] {
-		_, err := board.PlaceTile(tile)
+		err := board.addTileToBoard(tile)
 		if err != nil {
 			t.Fatalf("error placing tile number: %#v: %#v", i, err)
 		}
@@ -521,7 +521,7 @@ func TestBoardCompleteTwoMonasteriesAtOnce(t *testing.T) {
 	}
 
 	// place the last tile
-	_, err := board.PlaceTile(tiles[11])
+	err := board.addTileToBoard(tiles[11])
 	if err != nil {
 		t.Fatalf("error placing tile number: %#v: %#v", 11, err)
 	}

--- a/pkg/game/board_test.go
+++ b/pkg/game/board_test.go
@@ -17,16 +17,31 @@ import (
 )
 
 func TestBoardDeepClone(t *testing.T) {
-	oldPos := position.New(0, 1)
-	newPos := position.New(0, 2) // just one of new positions
+	oldPos := position.New(0, 2)
+	newPos := position.New(0, 3) // just one of new positions
 	newTile := test.GetTestPlacedTile()
+	newTile.Position = oldPos
+
+	expectedMeeplePos := position.New(0, 1)
+	expectedMeeple := elements.Meeple{
+		PlayerID: 1,
+		Type:     elements.NormalMeeple,
+	}
 
 	original := NewBoard(tilesets.StandardTileSet()).(*board)
-	clone := original.DeepClone().(*board)
-
-	_, err := clone.PlaceTile(newTile)
+	// add a tile with meeple to verify that it's still there on the original later
+	ptile := elements.ToPlacedTile(tiletemplates.TwoCityEdgesUpAndDownConnected())
+	ptile.Position = expectedMeeplePos
+	ptile.GetPlacedFeatureAtSide(side.Bottom, feature.City).Meeple = expectedMeeple
+	_, err := original.PlaceTile(ptile)
 	if err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
+	}
+
+	clone := original.DeepClone().(*board)
+	_, err = clone.PlaceTile(newTile)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// --- placeablePositions check ---
@@ -59,6 +74,28 @@ func TestBoardDeepClone(t *testing.T) {
 	cloneTiles := clone.Tiles()
 	if !slices.ContainsFunc(cloneTiles, cmpFunc) {
 		t.Fatalf("expected to find %#v in %#v", newTile, cloneTiles)
+	}
+
+	// check that meeple is still present on the original
+	originalTile, ok := original.GetTileAt(expectedMeeplePos)
+	if !ok {
+		t.Fatalf("expected to find a tile at %#v", expectedMeeplePos)
+	}
+	actual := originalTile.GetPlacedFeatureAtSide(side.Bottom, feature.City)
+	actualMeeple := actual.Meeple
+
+	if expectedMeeple != actualMeeple {
+		t.Fatalf("expected %#v, got %#v instead", expectedMeeple, actualMeeple)
+	}
+	// just to confirm that clone does not have the meeple
+	clonedTile, ok := clone.GetTileAt(expectedMeeplePos)
+	if !ok {
+		t.Fatalf("expected to find a tile at %#v", expectedMeeplePos)
+	}
+
+	clonedMeeple := clonedTile.GetPlacedFeatureAtSide(side.Bottom, feature.City).Meeple
+	if clonedMeeple.Type != elements.NoneMeeple {
+		t.Fatalf("expected %#v to have no meeple", clonedTile)
 	}
 }
 

--- a/pkg/game/game.go
+++ b/pkg/game/game.go
@@ -242,23 +242,20 @@ func (game *Game) PlayTurn(move elements.PlacedTile) error {
 		return err
 	}
 
-	// Score features and update meeple counts
+	// Score features
 	for playerID, receivedPoints := range scoreReport.ReceivedPoints {
 		player := game.players[playerID-1]
 		player.SetScore(player.Score() + receivedPoints)
 	}
 
+	// Return meeples to the players
 	for playerID, returnedMeeples := range scoreReport.ReturnedMeeples {
 		player := game.players[playerID-1]
 		for _, meeple := range returnedMeeples {
-			// return meeple to player
 			player.SetMeepleCount(
 				meeple.Type,
 				player.MeepleCount(meeple.Type)+1,
 			)
-
-			// remove meeple from board
-			game.board.RemoveMeeple(meeple.Position)
 		}
 	}
 

--- a/pkg/game/scoring_roads_test.go
+++ b/pkg/game/scoring_roads_test.go
@@ -71,7 +71,7 @@ func TestBoardScoreRoadLoop(t *testing.T) {
 	// --------------- Placing tile ----------------------
 
 	for i := range 5 {
-		_, err := board.PlaceTile(tiles[i])
+		err := board.addTileToBoard(tiles[i])
 		if err != nil {
 			t.Fatalf("error placing tile number: %#v ", i)
 		}
@@ -184,7 +184,7 @@ func TestBoardScoreRoadCityMonastery(t *testing.T) {
 
 	for i := range len(tiles) {
 
-		_, err := board.PlaceTile(tiles[i])
+		err := board.addTileToBoard(tiles[i])
 
 		if err != nil {
 			t.Fatalf("error placing tile number: %#v ", i)
@@ -249,7 +249,7 @@ func TestBoardScoreRoadMultipleMeeplesOnSameRoad(t *testing.T) {
 
 	// --------------- Placing tile ----------------------
 	for i := range len(tiles) {
-		_, err := board.PlaceTile(tiles[i])
+		err := board.addTileToBoard(tiles[i])
 
 		if err != nil {
 			t.Fatalf("error placing tile number: %#v ", i)


### PR DESCRIPTION
Before meeple removal was added (#55), `PlacedTile` was considered immutable. This already needed to be fixed in `Game.PlayTurn()` (#106) but today I found another place where this assumption was made but is no longer correct.

Ideally, I would actually prefer to remove the mutation of `PlacedTile` by updating `RemoveMeeple()` to modify a clone of the tile but that is not as easy to do - we'd need to update both `board.tiles` and `board.tilesMap` (the former requires search) as well as ensure that any code looking up the tile once (probably just `board.ScoreMeeples()`) is changed to look the tile up again *if* it performed meeple removal. In short: not worth it.

The key part is https://github.com/YetAnotherSpieskowcy/Carcassonne-Engine/pull/118/commits/571610c23c82ba731c7779520d5dbde47cb3140f
The other commits are adding tests and improving existing game/board split to make those tests viable - having to remove the meeples on the game side of things is a weird design choice.
