### PR TITLE
Fixed log performance

### DIFF
--- a/pkg/game/game.go
+++ b/pkg/game/game.go
@@ -53,7 +53,7 @@ func NewFromDeck(
 	deck deck.Deck, log logger.Logger,
 ) (*Game, error) {
 	if log == nil {
-		nullLogger := logger.New(io.Discard)
+		nullLogger := logger.NewEmpty()
 		log = &nullLogger
 	}
 	game := &Game{

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -54,3 +54,20 @@ func (logger *BaseLogger) CopyTo(dst Logger) error {
 	_ = dst
 	return ErrCopyToNotImplemented
 }
+
+type EmptyLogger struct{}
+
+func NewEmpty() EmptyLogger {
+	return EmptyLogger{}
+}
+
+func (*EmptyLogger) AsWriter() io.Writer {
+	return nil
+}
+
+func (*EmptyLogger) LogEvent(_ EventType, _ interface{}) error {
+	return nil
+}
+func (*EmptyLogger) CopyTo(_ Logger) error {
+	return nil
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -65,9 +65,9 @@ func (*EmptyLogger) AsWriter() io.Writer {
 	return nil
 }
 
-func (*EmptyLogger) LogEvent(_ EventType, _ interface{}) error {
+func (*EmptyLogger) LogEvent(eventName EventType, event interface{}) error { //nolint:revive // causes gopy to fail
 	return nil
 }
-func (*EmptyLogger) CopyTo(_ Logger) error {
+func (*EmptyLogger) CopyTo(dst Logger) error { //nolint:revive // causes gopy to fail
 	return nil
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -68,6 +68,7 @@ func (*EmptyLogger) AsWriter() io.Writer {
 func (*EmptyLogger) LogEvent(eventName EventType, event interface{}) error { //nolint:revive // causes gopy to fail
 	return nil
 }
+
 func (*EmptyLogger) CopyTo(dst Logger) error { //nolint:revive // causes gopy to fail
 	return nil
 }


### PR DESCRIPTION
Fixes #123 
``` 
                       │   0.bench    │                1.bench                │
                       │    sec/op    │    sec/op     vs base                 │
LongCity-32                2.036 ± ∞ ¹    1.893 ± ∞ ¹        ~ (p=1.000 n=1) ²
ManySmallCities-32        80.57µ ± ∞ ¹   48.12µ ± ∞ ¹        ~ (p=1.000 n=1) ²
LongField-32               2.052 ± ∞ ¹    2.313 ± ∞ ¹        ~ (p=1.000 n=1) ²
ManySmallFields-32        68.22µ ± ∞ ¹   37.37µ ± ∞ ¹        ~ (p=1.000 n=1) ²
LongMonastery-32           2.199 ± ∞ ¹    2.002 ± ∞ ¹        ~ (p=1.000 n=1) ²
ManySmallMonasteries-32   56.18µ ± ∞ ¹   35.97µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SingleExtraLongRoad-32     2.060 ± ∞ ¹    2.073 ± ∞ ¹        ~ (p=1.000 n=1) ²
ManyShortRoads-32         59.45µ ± ∞ ¹   36.32µ ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                   11.69m         8.991m        -23.06%
```