### PR TITLE
Check mid game score request

### DIFF
--- a/pkg/end_tests/four_player_game_test/four_player_game_test.go
+++ b/pkg/end_tests/four_player_game_test/four_player_game_test.go
@@ -157,6 +157,13 @@ func checkFirstTurn(game *gameMod.Game, t *testing.T) {
 		PlayerMeeples: []uint8{7 - 1, 7, 7, 7},
 		TurnNumber:    1,
 	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{0 + 1, 0, 0, 0},
+		TurnNumber:   1,
+	}.Run()
 }
 
 /*
@@ -212,6 +219,13 @@ func checkSecondTurn(game *gameMod.Game, t *testing.T) {
 		PlayerScores:  []uint32{0, 0 + 4, 0, 0},
 		PlayerMeeples: []uint8{6, 7 - 1 + 1, 7, 7},
 		TurnNumber:    2,
+	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{0 + 1, 4, 0, 0},
+		TurnNumber:   2,
 	}.Run()
 }
 
@@ -270,6 +284,13 @@ func checkThirdTurn(game *gameMod.Game, t *testing.T) {
 		TurnNumber:    3,
 	}.Run()
 
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{0 + 1, 4, 0 + 1, 0},
+		TurnNumber:   3,
+	}.Run()
+
 }
 
 /*
@@ -326,6 +347,13 @@ func checkFourthTurn(game *gameMod.Game, t *testing.T) {
 		PlayerMeeples: []uint8{6, 7, 6, 7 - 1},
 		TurnNumber:    4,
 	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{0 + 1, 4, 0 + 1, 0 + 2},
+		TurnNumber:   4,
+	}.Run()
 }
 
 /*
@@ -381,6 +409,13 @@ func checkFifthTurn(game *gameMod.Game, t *testing.T) {
 		PlayerScores:  []uint32{0, 4, 0, 0},
 		PlayerMeeples: []uint8{6 - 1, 7, 6, 6},
 		TurnNumber:    5,
+	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{0 + 2, 4, 0 + 1, 0 + 2},
+		TurnNumber:   5,
 	}.Run()
 }
 
@@ -449,6 +484,13 @@ func checkSixthTurn(game *gameMod.Game, t *testing.T) {
 		PlayerScores:  []uint32{0, 4, 0, 0},
 		PlayerMeeples: []uint8{5, 7 - 1, 6, 6},
 		TurnNumber:    6,
+	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{0 + 3, 4, 0 + 1, 0 + 2},
+		TurnNumber:   6,
 	}.Run()
 }
 
@@ -529,6 +571,13 @@ func checkSeventhTurn(game *gameMod.Game, t *testing.T) {
 		PlayerMeeples: []uint8{5, 6, 6 - 1 + 1, 6},
 		TurnNumber:    7,
 	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{0 + 3 + 3, 4, 4 + 1, 0 + 2},
+		TurnNumber:   7,
+	}.Run()
 }
 
 /*
@@ -596,6 +645,13 @@ func checkEighthTurn(game *gameMod.Game, t *testing.T) {
 		PlayerScores:  []uint32{0, 4, 4, 0},
 		PlayerMeeples: []uint8{5, 6, 6, 6 - 1},
 		TurnNumber:    8,
+	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{0 + 3 + 3, 4, 4 + 1, 0 + 2 + 3},
+		TurnNumber:   8,
 	}.Run()
 }
 
@@ -665,6 +721,13 @@ func checkNinthTurn(game *gameMod.Game, t *testing.T) {
 		PlayerScores:  []uint32{0, 4, 4, 0},
 		PlayerMeeples: []uint8{5 - 1, 6, 6, 5},
 		TurnNumber:    9,
+	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{0 + 3 + 3*3, 4, 4 + 1, 0 + 3 + 3},
+		TurnNumber:   9,
 	}.Run()
 }
 
@@ -744,6 +807,13 @@ func checkTenthTurn(game *gameMod.Game, t *testing.T) {
 		PlayerScores:  []uint32{0, 4, 4, 0 + 4},
 		PlayerMeeples: []uint8{4, 6 - 1, 6, 5 + 1},
 		TurnNumber:    10,
+	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{0 + 3 + 3*3, 4 + 3, 4 + 1, 4 + 3},
+		TurnNumber:   10,
 	}.Run()
 }
 
@@ -834,6 +904,13 @@ func checkEleventhTurn(game *gameMod.Game, t *testing.T) {
 		PlayerMeeples: []uint8{4 + 1, 5, 6 - 1, 6 + 1},
 		TurnNumber:    11,
 	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{4 + 3*3, 4 + 3, 4 + 1 + 1, 8},
+		TurnNumber:   11,
+	}.Run()
 }
 
 /*
@@ -902,6 +979,13 @@ func checkTwelfthTurn(game *gameMod.Game, t *testing.T) {
 		PlayerScores:  []uint32{4, 4, 4, 8},
 		PlayerMeeples: []uint8{5, 5, 5, 7 - 1},
 		TurnNumber:    12,
+	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{4 + 3*3, 4 + 3, 4 + 1 + 1, 8 + 1},
+		TurnNumber:   12,
 	}.Run()
 }
 

--- a/pkg/end_tests/two_player_game_test/two_player_game_test.go
+++ b/pkg/end_tests/two_player_game_test/two_player_game_test.go
@@ -146,6 +146,13 @@ func checkFirstTurn(game *gameMod.Game, t *testing.T) {
 		PlayerMeeples: []uint8{7 - 1 + 1, 7},
 		TurnNumber:    1,
 	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{4, 0},
+		TurnNumber:   1,
+	}.Run()
 }
 
 // road turn
@@ -196,6 +203,13 @@ func checkSecondTurn(game *gameMod.Game, t *testing.T) {
 		PlayerScores:  []uint32{4, 0},
 		PlayerMeeples: []uint8{7, 7 - 1},
 		TurnNumber:    2,
+	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{4, 0 + 2},
+		TurnNumber:   2,
 	}.Run()
 }
 
@@ -260,6 +274,13 @@ func checkThirdTurn(game *gameMod.Game, t *testing.T) {
 		PlayerMeeples: []uint8{7 - 1, 6},
 		TurnNumber:    3,
 	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{4 + 3, 0 + 4},
+		TurnNumber:   3,
+	}.Run()
 }
 
 // T cross road
@@ -322,6 +343,13 @@ func checkFourthTurn(game *gameMod.Game, t *testing.T) {
 		PlayerScores:  []uint32{4, 0},
 		PlayerMeeples: []uint8{6, 6 - 1},
 		TurnNumber:    4,
+	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{4 + 3, 0 + 5 + 1},
+		TurnNumber:   4,
 	}.Run()
 }
 
@@ -397,6 +425,13 @@ func checkFifthTurn(game *gameMod.Game, t *testing.T) {
 		TurnNumber:    5,
 	}.Run()
 
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{4 + 3 + 3, 2 + 5},
+		TurnNumber:   5,
+	}.Run()
+
 }
 
 // Two city edges not connected
@@ -447,6 +482,13 @@ func checkSixthTurn(game *gameMod.Game, t *testing.T) {
 		PlayerScores:  []uint32{4, 2},
 		PlayerMeeples: []uint8{5, 6 - 1},
 		TurnNumber:    6,
+	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{4 + 3 + 3, 2 + 5 + 1},
+		TurnNumber:   6,
 	}.Run()
 }
 
@@ -523,6 +565,13 @@ func checkSeventhTurn(game *gameMod.Game, t *testing.T) {
 		PlayerMeeples: []uint8{5 - 1, 5 + 1},
 		TurnNumber:    7,
 	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{4 + 3 + 3 + 1, 6 + 5},
+		TurnNumber:   7,
+	}.Run()
 }
 
 // straight road
@@ -575,6 +624,13 @@ func checkEighthTurn(game *gameMod.Game, t *testing.T) {
 		PlayerScores:  []uint32{4, 6},
 		PlayerMeeples: []uint8{4, 6 - 1},
 		TurnNumber:    8,
+	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{4 + 3 + 1 + 3, 6 + 5 + 1},
+		TurnNumber:   8,
 	}.Run()
 }
 
@@ -651,6 +707,14 @@ func checkNinthTurn(game *gameMod.Game, t *testing.T) {
 		PlayerMeeples: []uint8{4 - 1, 5 + 1},
 		TurnNumber:    9,
 	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{4 + 3 + 3 + 1 + 3, 12 + 1},
+		TurnNumber:   9,
+	}.Run()
+
 }
 
 // Two city edges not connected
@@ -716,6 +780,13 @@ func checkTenthTurn(game *gameMod.Game, t *testing.T) {
 		PlayerMeeples: []uint8{3 + 1, 6 - 1},
 		TurnNumber:    10,
 	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{8 + 3 + 3 + 3, 12 + 1 + 1},
+		TurnNumber:   10,
+	}.Run()
 }
 
 // road turn
@@ -769,6 +840,13 @@ func checkEleventhTurn(game *gameMod.Game, t *testing.T) {
 		PlayerMeeples: []uint8{4, 5},
 		TurnNumber:    11,
 	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{8 + 3*3 + 3, 12 + 2 + 1},
+		TurnNumber:   11,
+	}.Run()
 }
 
 // straight road
@@ -821,6 +899,13 @@ func checkTwelfthTurn(game *gameMod.Game, t *testing.T) {
 		PlayerScores:  []uint32{8, 12},
 		PlayerMeeples: []uint8{4, 5},
 		TurnNumber:    12,
+	}.Run()
+
+	test.CheckMidGameScore{
+		Game:         game,
+		TestingT:     t,
+		PlayerScores: []uint32{8 + 3*3 + 3, 12 + 3 + 1},
+		TurnNumber:   12,
 	}.Run()
 }
 

--- a/pkg/game/board.go
+++ b/pkg/game/board.go
@@ -297,6 +297,7 @@ func (board *board) roadCanBePlaced(checkedTile elements.PlacedTile, checkedRoad
 			neighbourTile,
 			neighbourRoad.Feature,
 			true,
+			false,
 		)
 		if len(scoreReport.ReturnedMeeples) != 0 {
 			return false
@@ -392,7 +393,7 @@ func (board *board) checkCompleted(tile elements.PlacedTile) elements.ScoreRepor
 	scoreReport := elements.NewScoreReport()
 	board.cityManager.UpdateCities(tile)
 	scoreReport.Join(board.cityManager.ScoreCities(false))
-	scoreReport.Join(board.scoreRoads(tile, false))
+	scoreReport.Join(board.scoreRoads(tile, false, false))
 	scoreReport.Join(board.scoreMonasteries(tile, false))
 
 	for _, returnedMeeples := range scoreReport.ReturnedMeeples {
@@ -554,7 +555,7 @@ Calculates score for road.
 
 returns: ScoreReport, checked sides of the start tile (also including loop)
 */
-func (board *board) scoreRoadCompletion(tile elements.PlacedTile, road feature.Feature, forceScore bool) (elements.ScoreReport, side.Side) {
+func (board *board) scoreRoadCompletion(tile elements.PlacedTile, road feature.Feature, forceScore bool, scoreOnlyRoadWithMeepleOnTile bool) (elements.ScoreReport, side.Side) {
 	var meeples = []elements.MeepleWithPosition{}
 	var leftSide, rightSide side.Side
 	var score = 1
@@ -587,6 +588,11 @@ func (board *board) scoreRoadCompletion(tile elements.PlacedTile, road feature.F
 			roadRight.Meeple,
 			tile.Position),
 		)
+	}
+
+	// if there was no found meeple on a road on the tested tile, when meeple was expected there
+	if len(meeples) == 0 && scoreOnlyRoadWithMeepleOnTile {
+		return elements.NewScoreReport(), leftSide | rightSide
 	}
 
 	// check road in "left" direction
@@ -629,9 +635,13 @@ func (board *board) scoreRoadCompletion(tile elements.PlacedTile, road feature.F
 }
 
 /*
-Calculates summary score report from all roads on a tile
+Calculates summary score report from all roads on a tile.
+
+scoreOnlyRoadWithMeepleOnTile parameter if for edge case, wwhen mid game score is calculated. The same meeple can be couted twice during mid game scoring.
+scoreRoads() counts all roads on a tile. So for each meeple all roads on the tile are checked. Thus due to crossroad, a meeple may be counted twice.
+The simples solution to that, it to force checking only road with the meeple on that tile. :/
 */
-func (board *board) scoreRoads(placedTile elements.PlacedTile, forceScore bool) elements.ScoreReport {
+func (board *board) scoreRoads(placedTile elements.PlacedTile, forceScore bool, scoreOnlyRoadWithMeepleOnTile bool) elements.ScoreReport {
 	scoreReport := elements.NewScoreReport()
 	var tile = elements.ToTile(placedTile)
 	var roads = tile.Roads()
@@ -641,7 +651,7 @@ func (board *board) scoreRoads(placedTile elements.PlacedTile, forceScore bool) 
 	for _, road := range roads {
 		// check if the side of the tile was not already checked (special test case reference: TestBoardScoreRoadLoopCrossroad)
 		if !checkedRoadSides.OverlapsSide(road.Sides) {
-			scoreReportTemp, roadSide := board.scoreRoadCompletion(placedTile, road, forceScore)
+			scoreReportTemp, roadSide := board.scoreRoadCompletion(placedTile, road, forceScore, scoreOnlyRoadWithMeepleOnTile)
 			scoreReport.Join(scoreReportTemp)
 			checkedRoadSides |= roadSide
 		}
@@ -675,7 +685,7 @@ func (board *board) ScoreMeeples(final bool) elements.ScoreReport {
 			if feat.Meeple.PlayerID != 0 && !meeplesReport.MeepleInReport(elements.NewMeepleWithPosition(feat.Meeple, pTile.Position)) {
 				switch feat.FeatureType {
 				case feature.Road:
-					miniReport.Join(board.scoreRoads(pTile, true))
+					miniReport.Join(board.scoreRoads(pTile, true, !final))
 				case feature.Field:
 					field := field.New(feat, pTile)
 					field.Expand(board, board.cityManager)

--- a/pkg/game/scoring_roads_test.go
+++ b/pkg/game/scoring_roads_test.go
@@ -75,7 +75,7 @@ func TestBoardScoreRoadLoop(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error placing tile number: %#v ", i)
 		}
-		report = board.scoreRoads(tiles[i], false, false)
+		report = board.scoreRoads(tiles[i], false)
 		for _, playerID := range []elements.ID{1, 2} {
 			if report.ReceivedPoints[playerID] != expectedScores[i] {
 				t.Fatalf("placing tile number: %#v failed. expected %+v for player %v, got %+v instead", i, expectedScores[i], playerID, report.ReceivedPoints[playerID])
@@ -190,7 +190,7 @@ func TestBoardScoreRoadCityMonastery(t *testing.T) {
 			t.Fatalf("error placing tile number: %#v ", i)
 		}
 
-		report = board.scoreRoads(tiles[i], false, false)
+		report = board.scoreRoads(tiles[i], false)
 		if report.ReceivedPoints[1] != expectedScores[i] {
 			t.Fatalf("placing tile number: %#v failed. expected %+v, got %+v instead", i, expectedScores[i], report.ReceivedPoints[1])
 		}
@@ -255,7 +255,7 @@ func TestBoardScoreRoadMultipleMeeplesOnSameRoad(t *testing.T) {
 			t.Fatalf("error placing tile number: %#v ", i)
 		}
 
-		report = board.scoreRoads(tiles[i], false, false)
+		report = board.scoreRoads(tiles[i], false)
 		if report.ReceivedPoints[1] != expectedScores[i] {
 			t.Fatalf("placing tile number: %#v failed. expected %+v, got %+v instead", i, expectedScores[i], report.ReceivedPoints[1])
 		}
@@ -355,7 +355,7 @@ func TestScoreRoadPreventCheckingWithNoSideAtTile5(t *testing.T) {
 			t.Fatalf("error placing tile number: %#v ", i+1)
 		}
 
-		report = board.scoreRoads(tiles[i], false, false)
+		report = board.scoreRoads(tiles[i], false)
 		for playerID, points := range report.ReceivedPoints {
 			if points != expectedScores[i][playerID] {
 				t.Fatalf("Player %#v placing tile number: %#v failed. Received points:%#v,  expected %#v", playerID, i+1, points, expectedScores[i][playerID])

--- a/pkg/game/scoring_roads_test.go
+++ b/pkg/game/scoring_roads_test.go
@@ -75,7 +75,7 @@ func TestBoardScoreRoadLoop(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error placing tile number: %#v ", i)
 		}
-		report = board.scoreRoads(tiles[i], false)
+		report = board.scoreRoads(tiles[i], false, false)
 		for _, playerID := range []elements.ID{1, 2} {
 			if report.ReceivedPoints[playerID] != expectedScores[i] {
 				t.Fatalf("placing tile number: %#v failed. expected %+v for player %v, got %+v instead", i, expectedScores[i], playerID, report.ReceivedPoints[playerID])
@@ -190,7 +190,7 @@ func TestBoardScoreRoadCityMonastery(t *testing.T) {
 			t.Fatalf("error placing tile number: %#v ", i)
 		}
 
-		report = board.scoreRoads(tiles[i], false)
+		report = board.scoreRoads(tiles[i], false, false)
 		if report.ReceivedPoints[1] != expectedScores[i] {
 			t.Fatalf("placing tile number: %#v failed. expected %+v, got %+v instead", i, expectedScores[i], report.ReceivedPoints[1])
 		}
@@ -255,7 +255,7 @@ func TestBoardScoreRoadMultipleMeeplesOnSameRoad(t *testing.T) {
 			t.Fatalf("error placing tile number: %#v ", i)
 		}
 
-		report = board.scoreRoads(tiles[i], false)
+		report = board.scoreRoads(tiles[i], false, false)
 		if report.ReceivedPoints[1] != expectedScores[i] {
 			t.Fatalf("placing tile number: %#v failed. expected %+v, got %+v instead", i, expectedScores[i], report.ReceivedPoints[1])
 		}
@@ -355,7 +355,7 @@ func TestScoreRoadPreventCheckingWithNoSideAtTile5(t *testing.T) {
 			t.Fatalf("error placing tile number: %#v ", i+1)
 		}
 
-		report = board.scoreRoads(tiles[i], false)
+		report = board.scoreRoads(tiles[i], false, false)
 		for playerID, points := range report.ReceivedPoints {
 			if points != expectedScores[i][playerID] {
 				t.Fatalf("Player %#v placing tile number: %#v failed. Received points:%#v,  expected %#v", playerID, i+1, points, expectedScores[i][playerID])

--- a/pkg/game/test/game.go
+++ b/pkg/game/test/game.go
@@ -15,6 +15,7 @@ type Game interface {
 	PlayTurn(move elements.PlacedTile) error
 	GetPlayerByID(playerID elements.ID) elements.Player
 	GetBoard() elements.Board
+	GetMidGameScore() elements.ScoreReport
 }
 
 type T interface {
@@ -125,6 +126,25 @@ func (turn VerifyMeepleExistence) Run() {
 	} else {
 		if placedFeature.Meeple.Type != elements.NoneMeeple {
 			turn.TestingT.Fatalf("Turn %d: Meeple hasn't been removed!", turn.TurnNumber)
+		}
+	}
+}
+
+type CheckMidGameScore struct {
+	Game         Game
+	TestingT     T
+	PlayerScores []uint32
+	TurnNumber   uint
+}
+
+func (turn CheckMidGameScore) Run() {
+
+	mid_score := turn.Game.GetMidGameScore()
+
+	for id, score := range mid_score.ReceivedPoints {
+		// check points
+		if score != turn.PlayerScores[int(id)-1] {
+			turn.TestingT.Fatalf("Turn %d: Player %d received wrong amount of points! Expected: %d  Got: %d ", turn.TurnNumber, id, turn.PlayerScores[int(id)-1], score)
 		}
 	}
 }

--- a/pkg/game/test/game.go
+++ b/pkg/game/test/game.go
@@ -139,9 +139,9 @@ type CheckMidGameScore struct {
 
 func (turn CheckMidGameScore) Run() {
 
-	mid_score := turn.Game.GetMidGameScore()
+	midScore := turn.Game.GetMidGameScore()
 
-	for id, score := range mid_score.ReceivedPoints {
+	for id, score := range midScore.ReceivedPoints {
 		// check points
 		if score != turn.PlayerScores[int(id)-1] {
 			turn.TestingT.Fatalf("Turn %d: Player %d received wrong amount of points! Expected: %d  Got: %d ", turn.TurnNumber, id, turn.PlayerScores[int(id)-1], score)


### PR DESCRIPTION
additionaly fixed checking meeple twice in mid game score. Meeple could be counted twice when it was in a middle of a road, and there was second meeple on a crossroad (on a different road), but calculating from that crossroad we would count first meeple again. Now added check to limit to road where meeple is on that tile, when midgamescore.

Fixes #134 