### PR TITLE
prepare slice instead of append

### DIFF
--- a/pkg/tiles/tile.go
+++ b/pkg/tiles/tile.go
@@ -89,10 +89,10 @@ func (tile Tile) Rotate(rotations uint) Tile {
 		return tile
 	}
 
-	var newFeatures []featureMod.Feature
+	var newFeatures = make([]featureMod.Feature, len(tile.Features))
 
-	for _, feature := range tile.Features {
-		newFeatures = append(newFeatures, feature.Rotate(rotations))
+	for i, feature := range tile.Features {
+		newFeatures[i] = feature.Rotate(rotations)
 	}
 
 	tile.Features = newFeatures


### PR DESCRIPTION
convert append in loop, for reserving array once in tile rotate.

cpu: Intel(R) Core(TM) i5-8500 CPU @ 3.00GHz
                        │  old.txt      │            new.txt   
         │
                        │    sec/op    │    sec/op     vs base       
         │
CloneGameTest-6           733.2m ± ∞ ¹   721.3m ± ∞ ¹       ~ (p=0.667 n=2) ²
GetLegalMovesTest-6        7.931 ± ∞ ¹    7.644 ± ∞ ¹       ~ (p=0.333 n=2) ²
GetMidGameScoreTest-6     20.61m ± ∞ ¹   20.09m ± ∞ ¹       ~ (p=0.667 n=2) ²
GetRemainingTilesTest-6   11.02m ± ∞ ¹   11.24m ± ∞ ¹       ~ (p=0.667 n=2) ²
PlayTurnTest-6            140.8m ± ∞ ¹   137.8m ± ∞ ¹       ~ (p=0.333 n=2) ²
geomean                   179.4m         176.6m        -1.61%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

Zrobiłem 2 dla dwóch próbek, bo dla pięciu to wywaliło, że za długie ;/. Ale generalnie jest tam lekkie przyspieszenie